### PR TITLE
8.0.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,23 +33,22 @@ penguins-eggs, at the moment 2021 may is a mature tool and is extremely usefull,
 
 Try penguins-eggs yes, it is a console utility - no GUI - but don't be scared, penguins-eggs is a console command - really very simple - if you are able to open a terminal, you can use it and yours final users will enjoy of full gui and pratical installer to install your livecd.
 
-## addons
+### addons
 Starting with version 7.6.x, an addons architecture was added to eggs, allowing third parties to develop extensions. Note that currently we have an extension for the theme that includes both branding calamares, link and installer icon. In addition, also as an addon has been developed choose between GUI or CLI installation, adjust the video resolution, remote support, etc.
 
-## backup
+### backup
 From version 8.0.10 You can use the backup mode by simply adding --backup in the produce command. This way eggs will save your users data and accounts and will not add a live user, you will have to log in with the main user of your system with the his password. **Note:** since eggs always configures autologin, you may have a security risk with valuable data. Use this option only for your personal stuff and do not share the iso on the network.
 
-## krill
+### krill
 Starting with eggs 8.0.0 I included a new CLI installer named krill. krill let you to install your system in a nice CLI interface using the same, configuration created by eggs for [calamares](calamares.io). This lead to have "about the same" experience installing, from old distros to new one and for GUI and CLI. To force using krill in place of calamares in a GUI system just: **sudo eggs install --cli**
 
-## mom and dad
-I added two light assistants integrated with eggs: mom and dad. While mom is a bash script with whiptail - and guides the user to the various commands and documentation, dad started as a short way to create the iso. All you have to do is type in **sudo eggs dad** and follow simple instructions. It it possible too to short the way to reset configuration **sudo dad -c** or - again more fast - reset configuration, load defaults, kill previous eggs. Type just **sudo eggs dad -d** and you will immidiatly able to produce the egg in the default nest /home/eggs.
+### mom and dad
+I've added two lightweight assistants integrated with eggs: mom and dad. While mom is a bash script with whiptail - and guides the user to the various commands and documentation, dad started as a short way to create isos. All you have to do is type **sudo eggs dad** and follow simple instructions. You can also shortcut the way to reset the configuration **sudo dad -c** or - even faster - reset the configuration, load defaults, kill created isos. Simply type **sudo eggs dad -d** and you will immediately be able to produce the egg in the default /home/eggs nest.
 
 I suggest to leave the default values unchanged during the development of your remaster. You will be more fast in producing eggs, enjoy of dad after reinstalling eggs. If you need more space, simply mount your big device in /home/eggs.
 
-## yolk 
+### yolk 
 yolk so called - staying on the subject of eggs - is a local repository included in the livecd that contains a minimum of indispensable packages during installation. Thanks to yolk, you can safely install your system without the need of an active internet connection.
-
 
 ## What distributions can I use?
 eggs was born on Debian strecth/buster, but actually full support Debian from jessie to sid (bullseye), Devuan beowulf, Ubuntu focal, bionic and derivatives. I actually try it against Debian varius versions, before releases. I tried it successfully in LMDE 4 debbie, and deepin. eggs, generally must work with all the derivates from that distros.
@@ -59,7 +58,7 @@ Some examples of iso images remastered with eggs are in the [sourceforge page of
 ## What architecture can I use?
 From eggs v. 8.0.4 I'm releasing eggs in 4 differents architectures: **i386**, **amd64**, **arm64** and **armel**. eggs - at the moment - produce in i386 and amd64, but can be installed already on arm64 and armel. This mean who it is possible to install it in [raspberrypi](https://www.raspberrypi.org/), but again not possible to produce a [Raspberry Pi OS](https://www.raspberrypi.org/software/) egg in armel or arm64. I'm just working now to complete this step. 
 
-**Note:** Of course it is possible to produce iso for [Raspberry Pi Desktop](https://downloads.raspberrypi.org/rpd_x86/images/rpd_x86-2021-01-12/2021-01-11-raspios-buster-i386.iso) i386 based.
+**Note:** Of course it is possible to produce iso for [Raspberry Pi Desktop](https://downloads.raspberrypi.org/rpd_x86/images/) amd64 based.
 
 # Packages
 eggs is released as deb package and npm package. Most users need just deb version, if you already use nodejs the npm package can be installed too, 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ npm install -g penguins-eggs
 $ eggs COMMAND
 running command...
 $ eggs (-v|--version|version)
-penguins-eggs/8.0.15 linux-x64 node-v8.17.0
+penguins-eggs/8.0.16 linux-x64 node-v8.17.0
 $ eggs --help [COMMAND]
 USAGE
   $ eggs COMMAND
@@ -156,7 +156,7 @@ ALIASES
   $ eggs adjust
 ```
 
-_See code: [src/commands/adapt.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.15/src/commands/adapt.ts)_
+_See code: [src/commands/adapt.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.16/src/commands/adapt.ts)_
 
 ## `eggs autocomplete [SHELL]`
 
@@ -205,7 +205,7 @@ EXAMPLES
   install calamares and create it's configuration's files
 ```
 
-_See code: [src/commands/calamares.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.15/src/commands/calamares.ts)_
+_See code: [src/commands/calamares.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.16/src/commands/calamares.ts)_
 
 ## `eggs config`
 
@@ -229,7 +229,7 @@ EXAMPLE
   Configure eggs and install prerequisites
 ```
 
-_See code: [src/commands/config.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.15/src/commands/config.ts)_
+_See code: [src/commands/config.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.16/src/commands/config.ts)_
 
 ## `eggs dad`
 
@@ -246,7 +246,7 @@ OPTIONS
   -v, --verbose
 ```
 
-_See code: [src/commands/dad.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.15/src/commands/dad.ts)_
+_See code: [src/commands/dad.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.16/src/commands/dad.ts)_
 
 ## `eggs export:deb`
 
@@ -266,7 +266,7 @@ OPTIONS
   --i386       export i386 arch
 ```
 
-_See code: [src/commands/export/deb.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.15/src/commands/export/deb.ts)_
+_See code: [src/commands/export/deb.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.16/src/commands/export/deb.ts)_
 
 ## `eggs export:docs`
 
@@ -280,7 +280,7 @@ OPTIONS
   -h, --help  show CLI help
 ```
 
-_See code: [src/commands/export/docs.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.15/src/commands/export/docs.ts)_
+_See code: [src/commands/export/docs.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.16/src/commands/export/docs.ts)_
 
 ## `eggs export:iso`
 
@@ -296,7 +296,7 @@ OPTIONS
   -h, --help    show CLI help
 ```
 
-_See code: [src/commands/export/iso.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.15/src/commands/export/iso.ts)_
+_See code: [src/commands/export/iso.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.16/src/commands/export/iso.ts)_
 
 ## `eggs help [COMMAND]`
 
@@ -328,7 +328,7 @@ OPTIONS
   -v, --verbose
 ```
 
-_See code: [src/commands/info.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.15/src/commands/info.ts)_
+_See code: [src/commands/info.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.16/src/commands/info.ts)_
 
 ## `eggs install`
 
@@ -352,7 +352,7 @@ EXAMPLE
   Install the system using GUI or CLI installer
 ```
 
-_See code: [src/commands/install.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.15/src/commands/install.ts)_
+_See code: [src/commands/install.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.16/src/commands/install.ts)_
 
 ## `eggs kill`
 
@@ -371,7 +371,7 @@ EXAMPLE
   kill the eggs/free the nest
 ```
 
-_See code: [src/commands/kill.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.15/src/commands/kill.ts)_
+_See code: [src/commands/kill.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.16/src/commands/kill.ts)_
 
 ## `eggs mom`
 
@@ -385,7 +385,7 @@ OPTIONS
   -h, --help  show CLI help
 ```
 
-_See code: [src/commands/mom.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.15/src/commands/mom.ts)_
+_See code: [src/commands/mom.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.16/src/commands/mom.ts)_
 
 ## `eggs produce`
 
@@ -446,7 +446,7 @@ EXAMPLES
   in /home/eggs/ovarium and you can customize all you need
 ```
 
-_See code: [src/commands/produce.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.15/src/commands/produce.ts)_
+_See code: [src/commands/produce.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.16/src/commands/produce.ts)_
 
 ## `eggs remove`
 
@@ -470,7 +470,7 @@ EXAMPLES
   remove eggs, eggs configurations, packages prerequisites
 ```
 
-_See code: [src/commands/remove.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.15/src/commands/remove.ts)_
+_See code: [src/commands/remove.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.16/src/commands/remove.ts)_
 
 ## `eggs tools:clean`
 
@@ -488,7 +488,7 @@ ALIASES
   $ eggs clean
 ```
 
-_See code: [src/commands/tools/clean.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.15/src/commands/tools/clean.ts)_
+_See code: [src/commands/tools/clean.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.16/src/commands/tools/clean.ts)_
 
 ## `eggs tools:locales`
 
@@ -504,7 +504,7 @@ OPTIONS
   -v, --verbose    verbose
 ```
 
-_See code: [src/commands/tools/locales.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.15/src/commands/tools/locales.ts)_
+_See code: [src/commands/tools/locales.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.16/src/commands/tools/locales.ts)_
 
 ## `eggs tools:skel`
 
@@ -527,7 +527,7 @@ EXAMPLE
   desktop configuration of user mauro will get used as default
 ```
 
-_See code: [src/commands/tools/skel.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.15/src/commands/tools/skel.ts)_
+_See code: [src/commands/tools/skel.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.16/src/commands/tools/skel.ts)_
 
 ## `eggs tools:stat`
 
@@ -546,7 +546,7 @@ ALIASES
   $ eggs stat
 ```
 
-_See code: [src/commands/tools/stat.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.15/src/commands/tools/stat.ts)_
+_See code: [src/commands/tools/stat.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.16/src/commands/tools/stat.ts)_
 
 ## `eggs tools:yolk`
 
@@ -564,7 +564,7 @@ EXAMPLE
   $ eggs yolk -v
 ```
 
-_See code: [src/commands/tools/yolk.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.15/src/commands/tools/yolk.ts)_
+_See code: [src/commands/tools/yolk.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.16/src/commands/tools/yolk.ts)_
 
 ## `eggs update`
 
@@ -586,7 +586,7 @@ EXAMPLE
   update/upgrade the penguin's eggs tool
 ```
 
-_See code: [src/commands/update.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.15/src/commands/update.ts)_
+_See code: [src/commands/update.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.16/src/commands/update.ts)_
 <!-- commandsstop -->
 
 # Terminal samples

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ From version 8.0.10 You can use the backup mode by simply adding --backup in the
 ## krill
 Starting with eggs 8.0.0 I included a new CLI installer named krill. krill let you to install your system in a nice CLI interface using the same, configuration created by eggs for [calamares](calamares.io). This lead to have "about the same" experience installing, from old distros to new one and for GUI and CLI. To force using krill in place of calamares in a GUI system just: **sudo eggs install --cli**
 
-## mom and dad!
+## mom and dad
 I added two light assistants integrated with eggs: mom and dad. While mom is a bash script with whiptail - and guides the user to the various commands and documentation, dad started as a short way to create the iso. All you have to do is type in **sudo eggs dad** and follow simple instructions. It it possible too to short the way to reset configuration **sudo dad -c** or - again more fast - reset configuration, load defaults, kill previous eggs. Type just **sudo eggs dad -d** and you will immidiatly able to produce the egg in the default nest /home/eggs.
 
 I suggest to leave the default values unchanged during the development of your remaster. You will be more fast in producing eggs, enjoy of dad after reinstalling eggs. If you need more space, simply mount your big device in /home/eggs.

--- a/README.md
+++ b/README.md
@@ -291,8 +291,9 @@ USAGE
   $ eggs export:iso
 
 OPTIONS
-  -c, --clean  delete old ISOs before to copy
-  -h, --help   show CLI help
+  -b, --backup  export backup ISOs
+  -c, --clean   delete old ISOs before to copy
+  -h, --help    show CLI help
 ```
 
 _See code: [src/commands/export/iso.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.15/src/commands/export/iso.ts)_

--- a/README.md
+++ b/README.md
@@ -33,22 +33,23 @@ penguins-eggs, at the moment 2021 may is a mature tool and is extremely usefull,
 
 Try penguins-eggs yes, it is a console utility - no GUI - but don't be scared, penguins-eggs is a console command - really very simple - if you are able to open a terminal, you can use it and yours final users will enjoy of full gui and pratical installer to install your livecd.
 
-## Addons
-Starting with version 7.6.x an addons architecture was been added to eggs, that allows third parties to develop extensions. Note that we currently have an extension for the theme that includes both calamares branding and installer link and icon. In addition, also as addon has been developed others addons, to chosen hoosing between GUI or CLI installation, adapt video resolution, etc.
+## addons
+Starting with version 7.6.x, an addons architecture was added to eggs, allowing third parties to develop extensions. Note that currently we have an extension for the theme that includes both branding calamares, link and installer icon. In addition, also as an addon has been developed choose between GUI or CLI installation, adjust the video resolution, remote support, etc.
 
-## backup mode
-You can use the backup mode by simply adding --backup in the produce command. This way eggs will save your users data and accounts and will not add the a live user, you will have to log in with the main user of your system with the his password. **Note:** since eggs always configures autologin, you may have same a security risk with valuable data. Use this option only for your personal stuff and do not share the iso on the network.
+## backup
+From version 8.0.10 You can use the backup mode by simply adding --backup in the produce command. This way eggs will save your users data and accounts and will not add a live user, you will have to log in with the main user of your system with the his password. **Note:** since eggs always configures autologin, you may have a security risk with valuable data. Use this option only for your personal stuff and do not share the iso on the network.
+
+## krill
+Starting with eggs 8.0.0 I included a new CLI installer named krill. krill let you to install your system in a nice CLI interface using the same, configuration created by eggs for [calamares](calamares.io). This lead to have "about the same" experience installing, from old distros to new one and for GUI and CLI. To force using krill in place of calamares in a GUI system just: **sudo eggs install --cli**
+
+## mom and dad!
+I added two light assistants integrated with eggs: mom and dad. While mom is a bash script with whiptail - and guides the user to the various commands and documentation, dad started as a short way to create the iso. All you have to do is type in **sudo eggs dad** and follow simple instructions. It it possible too to short the way to reset configuration **sudo dad -c** or - again more fast - reset configuration, load defaults, kill previous eggs. Type just **sudo eggs dad -d** and you will immidiatly able to produce the egg in the default nest /home/eggs.
+
+I suggest to leave the default values unchanged during the development of your remaster. You will be more fast in producing eggs, enjoy of dad after reinstalling eggs. If you need more space, simply mount your big device in /home/eggs.
 
 ## yolk 
 yolk so called - staying on the subject of eggs - is a local repository included in the livecd that contains a minimum of indispensable packages during installation. Thanks to yolk, you can safely install your system without the need of an active internet connection.
 
-## krill
-Starting with eggs 8.0.0 I included a new CLI installer named krill. krill let you to install your system in a nice CLI interface using the same, configuration created by eggs for [calamares](calamares.io). This lead to have "about the same" experience installing, from old distros to new one and for GUI and CLI. To use krill in place of calamares in GUI system just: **sudo eggs install --cli**
-
-## Two great helpers: mom and dad!
-I added two light assistants integrated with eggs: mom and dad. While mom is a bash script with whiptail - and guides the user to the various commands and documentation, dad started as a short way to create the iso. All you have to do is type in **sudo eggs dad** and follow simple instructions. It it possible too to short the way to reset configuration **sudo dad -c** or - again more fast - reset configuration, load defaults, kill previous eggs. Type just **sudo eggs dad -d** and you will immidiatly able to produce the egg in the default nest /home/eggs.
-
-I suggest to leave the default values unchanged during the development of your remaster. You will be more fast in producing eggs, enjoy of dad after reinstalling eggs. If you need more space, simply mount your big device in /home/eggs.
 
 ## What distributions can I use?
 eggs was born on Debian strecth/buster, but actually full support Debian from jessie to sid (bullseye), Devuan beowulf, Ubuntu focal, bionic and derivatives. I actually try it against Debian varius versions, before releases. I tried it successfully in LMDE 4 debbie, and deepin. eggs, generally must work with all the derivates from that distros.

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,9 @@ You can follow the project also consulting the [commit history](https://github.c
 ## Changelog
 Versions are listed on reverse order, the first is the last one.
 
+### eggs-8.0.16
+* creating a backup produce ISO prefixed by "backup-" not "egg-of-", eggs export:iso include now --backup option too
+
 ### eggs-8.0.15
 * krill finally support changing keyboard
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "penguins-eggs",
-  "version": "8.0.15",
+  "version": "8.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "penguins-eggs",
   "shortName": "eggs",
   "description": "Perri's Brewery edition: remaster your system and distribuite it",
-  "version": "8.0.15",
+  "version": "8.0.16",
   "author": "Piero Proietti @pieroproietti",
   "bin": {
     "eggs": "bin/run"

--- a/src/classes/utils.tsx
+++ b/src/classes/utils.tsx
@@ -254,13 +254,13 @@ unknown target format aarch64-efi
     * @param basename
     * @returns eggName
     */
-   static getFilename(basename = ''): string {
+   static getVolid(basename = ''): string {
+      let volid = `${basename}-${this.machineArch()}_${Utils.formatDate(new Date())}`
 
-      let isoName = `${basename}-${this.machineArch()}_${Utils.formatDate(new Date())}`
-      if (isoName.length >= 28) {
-         isoName = isoName.substr(0, 28) // 28 +  4 .iso = 32 lunghezza max di volid
+      if (volid.length >= 28) {
+         volid = volid.substr(0, 28) // 28 +  4 .iso = 32 lunghezza max di volid
       }
-      return `${isoName}.iso`
+      return `${volid}.iso`
    }
 
    /**

--- a/src/commands/export/iso.ts
+++ b/src/commands/export/iso.ts
@@ -12,6 +12,7 @@ export default class ExportIso extends Command {
 
   static flags = {
     help: flags.help({ char: 'h' }),
+    backup: flags.boolean({ char: 'b', description: 'export backup ISOs' }),
     clean: flags.boolean({ char: 'c', description: 'delete old ISOs before to copy' }),
   }
 
@@ -22,6 +23,12 @@ export default class ExportIso extends Command {
     const Tu = new Tools()
     Utils.warning(ExportIso.description)
     await Tu.loadSettings()
+    if (flags.backup) {
+      if(Tu.snapshot_name.substring(0,7)==='egg-of-') {
+        Tu.snapshot_name = 'backup-' +Tu.snapshot_name.substring(7)
+      }
+    }
+
     let cmd = `ssh root@${Tu.config.remoteHost} rm -rf ${Tu.config.remotePathIso}${Tu.snapshot_name}*`
     if (flags.clean) {
       Utils.warning('cleaning destination...')


### PR DESCRIPTION
backup option now produce iso prefixd by  "backup-" not "egg-of-". In eggs export:iso added flag --backup too to export this kind of isos.