### PR TITLE
8.0.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ npm install -g penguins-eggs
 $ eggs COMMAND
 running command...
 $ eggs (-v|--version|version)
-penguins-eggs/8.0.23 linux-x64 node-v8.17.0
+penguins-eggs/8.0.24 linux-x64 node-v8.17.0
 $ eggs --help [COMMAND]
 USAGE
   $ eggs COMMAND
@@ -156,7 +156,7 @@ ALIASES
   $ eggs adjust
 ```
 
-_See code: [src/commands/adapt.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.23/src/commands/adapt.ts)_
+_See code: [src/commands/adapt.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/adapt.ts)_
 
 ## `eggs autocomplete [SHELL]`
 
@@ -205,7 +205,7 @@ EXAMPLES
   install calamares and create it's configuration's files
 ```
 
-_See code: [src/commands/calamares.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.23/src/commands/calamares.ts)_
+_See code: [src/commands/calamares.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/calamares.ts)_
 
 ## `eggs config`
 
@@ -229,7 +229,7 @@ EXAMPLE
   Configure eggs and install prerequisites
 ```
 
-_See code: [src/commands/config.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.23/src/commands/config.ts)_
+_See code: [src/commands/config.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/config.ts)_
 
 ## `eggs dad`
 
@@ -246,7 +246,7 @@ OPTIONS
   -v, --verbose
 ```
 
-_See code: [src/commands/dad.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.23/src/commands/dad.ts)_
+_See code: [src/commands/dad.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/dad.ts)_
 
 ## `eggs export:deb`
 
@@ -266,7 +266,7 @@ OPTIONS
   --i386       export i386 arch
 ```
 
-_See code: [src/commands/export/deb.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.23/src/commands/export/deb.ts)_
+_See code: [src/commands/export/deb.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/export/deb.ts)_
 
 ## `eggs export:docs`
 
@@ -280,7 +280,7 @@ OPTIONS
   -h, --help  show CLI help
 ```
 
-_See code: [src/commands/export/docs.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.23/src/commands/export/docs.ts)_
+_See code: [src/commands/export/docs.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/export/docs.ts)_
 
 ## `eggs export:iso`
 
@@ -296,7 +296,7 @@ OPTIONS
   -h, --help    show CLI help
 ```
 
-_See code: [src/commands/export/iso.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.23/src/commands/export/iso.ts)_
+_See code: [src/commands/export/iso.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/export/iso.ts)_
 
 ## `eggs help [COMMAND]`
 
@@ -328,8 +328,6 @@ OPTIONS
   -v, --verbose
 ```
 
-_See code: [src/commands/info.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.23/src/commands/info.ts)_
-
 ## `eggs install`
 
 command-line system installer - the egg became a penguin!
@@ -352,7 +350,7 @@ EXAMPLE
   Install the system using GUI or CLI installer
 ```
 
-_See code: [src/commands/install.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.23/src/commands/install.ts)_
+_See code: [src/commands/install.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/install.ts)_
 
 ## `eggs kill`
 
@@ -371,7 +369,7 @@ EXAMPLE
   kill the eggs/free the nest
 ```
 
-_See code: [src/commands/kill.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.23/src/commands/kill.ts)_
+_See code: [src/commands/kill.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/kill.ts)_
 
 ## `eggs mom`
 
@@ -385,7 +383,7 @@ OPTIONS
   -h, --help  show CLI help
 ```
 
-_See code: [src/commands/mom.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.23/src/commands/mom.ts)_
+_See code: [src/commands/mom.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/mom.ts)_
 
 ## `eggs produce`
 
@@ -446,7 +444,7 @@ EXAMPLES
   in /home/eggs/ovarium and you can customize all you need
 ```
 
-_See code: [src/commands/produce.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.23/src/commands/produce.ts)_
+_See code: [src/commands/produce.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/produce.ts)_
 
 ## `eggs remove`
 
@@ -470,7 +468,7 @@ EXAMPLES
   remove eggs, eggs configurations, packages prerequisites
 ```
 
-_See code: [src/commands/remove.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.23/src/commands/remove.ts)_
+_See code: [src/commands/remove.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/remove.ts)_
 
 ## `eggs tools:clean`
 
@@ -488,7 +486,7 @@ ALIASES
   $ eggs clean
 ```
 
-_See code: [src/commands/tools/clean.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.23/src/commands/tools/clean.ts)_
+_See code: [src/commands/tools/clean.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/tools/clean.ts)_
 
 ## `eggs tools:locales`
 
@@ -504,7 +502,7 @@ OPTIONS
   -v, --verbose    verbose
 ```
 
-_See code: [src/commands/tools/locales.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.23/src/commands/tools/locales.ts)_
+_See code: [src/commands/tools/locales.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/tools/locales.ts)_
 
 ## `eggs tools:skel`
 
@@ -527,7 +525,7 @@ EXAMPLE
   desktop configuration of user mauro will get used as default
 ```
 
-_See code: [src/commands/tools/skel.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.23/src/commands/tools/skel.ts)_
+_See code: [src/commands/tools/skel.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/tools/skel.ts)_
 
 ## `eggs tools:stat`
 
@@ -546,7 +544,7 @@ ALIASES
   $ eggs stat
 ```
 
-_See code: [src/commands/tools/stat.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.23/src/commands/tools/stat.ts)_
+_See code: [src/commands/tools/stat.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/tools/stat.ts)_
 
 ## `eggs tools:yolk`
 
@@ -564,7 +562,7 @@ EXAMPLE
   $ eggs yolk -v
 ```
 
-_See code: [src/commands/tools/yolk.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.23/src/commands/tools/yolk.ts)_
+_See code: [src/commands/tools/yolk.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/tools/yolk.ts)_
 
 ## `eggs update`
 
@@ -586,7 +584,7 @@ EXAMPLE
   update/upgrade the penguin's eggs tool
 ```
 
-_See code: [src/commands/update.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.23/src/commands/update.ts)_
+_See code: [src/commands/update.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/update.ts)_
 <!-- commandsstop -->
 
 # Terminal samples

--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ OPTIONS
   -v, --verbose
 ```
 
+_See code: [src/commands/info.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/info.ts)_
+
 ## `eggs install`
 
 command-line system installer - the egg became a penguin!

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,9 @@ You can follow the project also consulting the [commit history](https://github.c
 ## Changelog
 Versions are listed on reverse order, the first is the last one.
 
+### eggs-8.0.24
+* partial rewrite in perrisbrewery due a problem from same version 8.0.18 - 8.0.23. I hope it is solved, but need confirm
+
 ### eggs-8.0.22
 * just same refactoring and removed last ; in krill_prepare networking dns
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "penguins-eggs",
-  "version": "8.0.23",
+  "version": "8.0.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "penguins-eggs",
   "shortName": "eggs",
   "description": "Perri's Brewery edition: remaster your system and distribuite it",
-  "version": "8.0.23",
+  "version": "8.0.24",
   "author": "Piero Proietti @pieroproietti",
   "bin": {
     "eggs": "bin/run"


### PR DESCRIPTION
rewrite parts of perrisbrewery with intention of uniform it with pacman.

Perri's brewery take cure of dependencies as deb packages, pacman the same but it is necessary for npm packages - eggs in that case decide what are the deb prerequisites necessaries.

Actually Perri's brewery is written as vendor component added to penguins-eggs and running to insert that prerequisites in the template.control of the package deb of eggs.

I'm asking to myself it this is the best solution, ideally I want just one routine to manage dependencies.

