### PR TITLE
8.0.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ npm install -g penguins-eggs
 $ eggs COMMAND
 running command...
 $ eggs (-v|--version|version)
-penguins-eggs/8.0.25 linux-x64 node-v8.17.0
+penguins-eggs/8.0.26 linux-x64 node-v8.17.0
 $ eggs --help [COMMAND]
 USAGE
   $ eggs COMMAND
@@ -156,7 +156,7 @@ ALIASES
   $ eggs adjust
 ```
 
-_See code: [src/commands/adapt.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/adapt.ts)_
+_See code: [src/commands/adapt.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.26/src/commands/adapt.ts)_
 
 ## `eggs autocomplete [SHELL]`
 
@@ -205,7 +205,7 @@ EXAMPLES
   install calamares and create it's configuration's files
 ```
 
-_See code: [src/commands/calamares.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/calamares.ts)_
+_See code: [src/commands/calamares.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.26/src/commands/calamares.ts)_
 
 ## `eggs config`
 
@@ -229,7 +229,7 @@ EXAMPLE
   Configure eggs and install prerequisites
 ```
 
-_See code: [src/commands/config.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/config.ts)_
+_See code: [src/commands/config.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.26/src/commands/config.ts)_
 
 ## `eggs dad`
 
@@ -246,7 +246,7 @@ OPTIONS
   -v, --verbose
 ```
 
-_See code: [src/commands/dad.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/dad.ts)_
+_See code: [src/commands/dad.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.26/src/commands/dad.ts)_
 
 ## `eggs export:deb`
 
@@ -266,7 +266,7 @@ OPTIONS
   --i386       export i386 arch
 ```
 
-_See code: [src/commands/export/deb.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/export/deb.ts)_
+_See code: [src/commands/export/deb.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.26/src/commands/export/deb.ts)_
 
 ## `eggs export:docs`
 
@@ -280,7 +280,7 @@ OPTIONS
   -h, --help  show CLI help
 ```
 
-_See code: [src/commands/export/docs.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/export/docs.ts)_
+_See code: [src/commands/export/docs.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.26/src/commands/export/docs.ts)_
 
 ## `eggs export:iso`
 
@@ -296,7 +296,7 @@ OPTIONS
   -h, --help    show CLI help
 ```
 
-_See code: [src/commands/export/iso.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/export/iso.ts)_
+_See code: [src/commands/export/iso.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.26/src/commands/export/iso.ts)_
 
 ## `eggs help [COMMAND]`
 
@@ -328,7 +328,7 @@ OPTIONS
   -v, --verbose
 ```
 
-_See code: [src/commands/info.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/info.ts)_
+_See code: [src/commands/info.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.26/src/commands/info.ts)_
 
 ## `eggs install`
 
@@ -352,7 +352,7 @@ EXAMPLE
   Install the system using GUI or CLI installer
 ```
 
-_See code: [src/commands/install.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/install.ts)_
+_See code: [src/commands/install.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.26/src/commands/install.ts)_
 
 ## `eggs kill`
 
@@ -371,7 +371,7 @@ EXAMPLE
   kill the eggs/free the nest
 ```
 
-_See code: [src/commands/kill.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/kill.ts)_
+_See code: [src/commands/kill.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.26/src/commands/kill.ts)_
 
 ## `eggs mom`
 
@@ -385,7 +385,7 @@ OPTIONS
   -h, --help  show CLI help
 ```
 
-_See code: [src/commands/mom.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/mom.ts)_
+_See code: [src/commands/mom.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.26/src/commands/mom.ts)_
 
 ## `eggs produce`
 
@@ -446,7 +446,7 @@ EXAMPLES
   in /home/eggs/ovarium and you can customize all you need
 ```
 
-_See code: [src/commands/produce.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/produce.ts)_
+_See code: [src/commands/produce.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.26/src/commands/produce.ts)_
 
 ## `eggs remove`
 
@@ -470,7 +470,7 @@ EXAMPLES
   remove eggs, eggs configurations, packages prerequisites
 ```
 
-_See code: [src/commands/remove.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/remove.ts)_
+_See code: [src/commands/remove.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.26/src/commands/remove.ts)_
 
 ## `eggs tools:clean`
 
@@ -488,7 +488,7 @@ ALIASES
   $ eggs clean
 ```
 
-_See code: [src/commands/tools/clean.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/tools/clean.ts)_
+_See code: [src/commands/tools/clean.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.26/src/commands/tools/clean.ts)_
 
 ## `eggs tools:locales`
 
@@ -504,7 +504,7 @@ OPTIONS
   -v, --verbose    verbose
 ```
 
-_See code: [src/commands/tools/locales.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/tools/locales.ts)_
+_See code: [src/commands/tools/locales.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.26/src/commands/tools/locales.ts)_
 
 ## `eggs tools:skel`
 
@@ -527,7 +527,7 @@ EXAMPLE
   desktop configuration of user mauro will get used as default
 ```
 
-_See code: [src/commands/tools/skel.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/tools/skel.ts)_
+_See code: [src/commands/tools/skel.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.26/src/commands/tools/skel.ts)_
 
 ## `eggs tools:stat`
 
@@ -546,7 +546,7 @@ ALIASES
   $ eggs stat
 ```
 
-_See code: [src/commands/tools/stat.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/tools/stat.ts)_
+_See code: [src/commands/tools/stat.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.26/src/commands/tools/stat.ts)_
 
 ## `eggs tools:yolk`
 
@@ -564,7 +564,7 @@ EXAMPLE
   $ eggs yolk -v
 ```
 
-_See code: [src/commands/tools/yolk.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/tools/yolk.ts)_
+_See code: [src/commands/tools/yolk.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.26/src/commands/tools/yolk.ts)_
 
 ## `eggs update`
 
@@ -586,7 +586,7 @@ EXAMPLE
   update/upgrade the penguin's eggs tool
 ```
 
-_See code: [src/commands/update.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/update.ts)_
+_See code: [src/commands/update.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.26/src/commands/update.ts)_
 <!-- commandsstop -->
 
 # Terminal samples

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ npm install -g penguins-eggs
 $ eggs COMMAND
 running command...
 $ eggs (-v|--version|version)
-penguins-eggs/8.0.24 linux-x64 node-v8.17.0
+penguins-eggs/8.0.25 linux-x64 node-v8.17.0
 $ eggs --help [COMMAND]
 USAGE
   $ eggs COMMAND
@@ -156,7 +156,7 @@ ALIASES
   $ eggs adjust
 ```
 
-_See code: [src/commands/adapt.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/adapt.ts)_
+_See code: [src/commands/adapt.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/adapt.ts)_
 
 ## `eggs autocomplete [SHELL]`
 
@@ -205,7 +205,7 @@ EXAMPLES
   install calamares and create it's configuration's files
 ```
 
-_See code: [src/commands/calamares.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/calamares.ts)_
+_See code: [src/commands/calamares.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/calamares.ts)_
 
 ## `eggs config`
 
@@ -229,7 +229,7 @@ EXAMPLE
   Configure eggs and install prerequisites
 ```
 
-_See code: [src/commands/config.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/config.ts)_
+_See code: [src/commands/config.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/config.ts)_
 
 ## `eggs dad`
 
@@ -246,7 +246,7 @@ OPTIONS
   -v, --verbose
 ```
 
-_See code: [src/commands/dad.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/dad.ts)_
+_See code: [src/commands/dad.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/dad.ts)_
 
 ## `eggs export:deb`
 
@@ -266,7 +266,7 @@ OPTIONS
   --i386       export i386 arch
 ```
 
-_See code: [src/commands/export/deb.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/export/deb.ts)_
+_See code: [src/commands/export/deb.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/export/deb.ts)_
 
 ## `eggs export:docs`
 
@@ -280,7 +280,7 @@ OPTIONS
   -h, --help  show CLI help
 ```
 
-_See code: [src/commands/export/docs.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/export/docs.ts)_
+_See code: [src/commands/export/docs.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/export/docs.ts)_
 
 ## `eggs export:iso`
 
@@ -296,7 +296,7 @@ OPTIONS
   -h, --help    show CLI help
 ```
 
-_See code: [src/commands/export/iso.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/export/iso.ts)_
+_See code: [src/commands/export/iso.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/export/iso.ts)_
 
 ## `eggs help [COMMAND]`
 
@@ -328,7 +328,7 @@ OPTIONS
   -v, --verbose
 ```
 
-_See code: [src/commands/info.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/info.ts)_
+_See code: [src/commands/info.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/info.ts)_
 
 ## `eggs install`
 
@@ -352,7 +352,7 @@ EXAMPLE
   Install the system using GUI or CLI installer
 ```
 
-_See code: [src/commands/install.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/install.ts)_
+_See code: [src/commands/install.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/install.ts)_
 
 ## `eggs kill`
 
@@ -371,7 +371,7 @@ EXAMPLE
   kill the eggs/free the nest
 ```
 
-_See code: [src/commands/kill.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/kill.ts)_
+_See code: [src/commands/kill.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/kill.ts)_
 
 ## `eggs mom`
 
@@ -385,7 +385,7 @@ OPTIONS
   -h, --help  show CLI help
 ```
 
-_See code: [src/commands/mom.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/mom.ts)_
+_See code: [src/commands/mom.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/mom.ts)_
 
 ## `eggs produce`
 
@@ -446,7 +446,7 @@ EXAMPLES
   in /home/eggs/ovarium and you can customize all you need
 ```
 
-_See code: [src/commands/produce.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/produce.ts)_
+_See code: [src/commands/produce.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/produce.ts)_
 
 ## `eggs remove`
 
@@ -470,7 +470,7 @@ EXAMPLES
   remove eggs, eggs configurations, packages prerequisites
 ```
 
-_See code: [src/commands/remove.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/remove.ts)_
+_See code: [src/commands/remove.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/remove.ts)_
 
 ## `eggs tools:clean`
 
@@ -488,7 +488,7 @@ ALIASES
   $ eggs clean
 ```
 
-_See code: [src/commands/tools/clean.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/tools/clean.ts)_
+_See code: [src/commands/tools/clean.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/tools/clean.ts)_
 
 ## `eggs tools:locales`
 
@@ -504,7 +504,7 @@ OPTIONS
   -v, --verbose    verbose
 ```
 
-_See code: [src/commands/tools/locales.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/tools/locales.ts)_
+_See code: [src/commands/tools/locales.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/tools/locales.ts)_
 
 ## `eggs tools:skel`
 
@@ -527,7 +527,7 @@ EXAMPLE
   desktop configuration of user mauro will get used as default
 ```
 
-_See code: [src/commands/tools/skel.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/tools/skel.ts)_
+_See code: [src/commands/tools/skel.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/tools/skel.ts)_
 
 ## `eggs tools:stat`
 
@@ -546,7 +546,7 @@ ALIASES
   $ eggs stat
 ```
 
-_See code: [src/commands/tools/stat.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/tools/stat.ts)_
+_See code: [src/commands/tools/stat.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/tools/stat.ts)_
 
 ## `eggs tools:yolk`
 
@@ -564,7 +564,7 @@ EXAMPLE
   $ eggs yolk -v
 ```
 
-_See code: [src/commands/tools/yolk.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/tools/yolk.ts)_
+_See code: [src/commands/tools/yolk.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/tools/yolk.ts)_
 
 ## `eggs update`
 
@@ -586,7 +586,7 @@ EXAMPLE
   update/upgrade the penguin's eggs tool
 ```
 
-_See code: [src/commands/update.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.24/src/commands/update.ts)_
+_See code: [src/commands/update.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.25/src/commands/update.ts)_
 <!-- commandsstop -->
 
 # Terminal samples

--- a/changelog.md
+++ b/changelog.md
@@ -19,7 +19,7 @@ You can follow the project also consulting the [commit history](https://github.c
 Versions are listed on reverse order, the first is the last one.
 
 ### eggs-8.0.26
-* eggs produce --backup now is working with luks: all users accounts and their home are saved in crypted volume
+* eggs produce --backup working with luks: all users accounts and their home are saved in crypted volume. bugfix postrm
 
 ### eggs-8.0.24
 * partial rewrite in perrisbrewery due a problem from same version 8.0.18 - 8.0.23. I hope it is solved, but need confirm

--- a/changelog.md
+++ b/changelog.md
@@ -19,7 +19,7 @@ You can follow the project also consulting the [commit history](https://github.c
 Versions are listed on reverse order, the first is the last one.
 
 ### eggs-8.0.26
-* eggs produce --backup working with luks: all users accounts and their home are saved in crypted volume. bugfix postrm
+* eggs produce --backup working with luks: all users accounts and their home are saved in crypted volume. bugfix postrm. I added cryptsetup to the dependencies, so you will be forced to use sudo apt install -f to install eggs
 
 ### eggs-8.0.24
 * partial rewrite in perrisbrewery due a problem from same version 8.0.18 - 8.0.23. I hope it is solved, but need confirm

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,9 @@ You can follow the project also consulting the [commit history](https://github.c
 ## Changelog
 Versions are listed on reverse order, the first is the last one.
 
+### eggs-8.0.26
+* eggs produce --backup now is working with luks: all users accounts and their home are saved in crypted volume
+
 ### eggs-8.0.24
 * partial rewrite in perrisbrewery due a problem from same version 8.0.18 - 8.0.23. I hope it is solved, but need confirm
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "penguins-eggs",
-  "version": "8.0.24",
+  "version": "8.0.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "penguins-eggs",
-  "version": "8.0.25",
+  "version": "8.0.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "penguins-eggs",
   "shortName": "eggs",
   "description": "Perri's Brewery edition: remaster your system and distribuite it",
-  "version": "8.0.24",
+  "version": "8.0.25",
   "author": "Piero Proietti @pieroproietti",
   "bin": {
     "eggs": "bin/run"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "penguins-eggs",
   "shortName": "eggs",
   "description": "Perri's Brewery edition: remaster your system and distribuite it",
-  "version": "8.0.25",
+  "version": "8.0.26",
   "author": "Piero Proietti @pieroproietti",
   "bin": {
     "eggs": "bin/run"

--- a/perrisbrewery/scripts/postinst
+++ b/perrisbrewery/scripts/postinst
@@ -38,8 +38,9 @@ case "$1" in
         fi
 
         # Avvia configurazione automatica
-        echo "eggs was installed, now configuring it..." 
         eggs config --nointeractive
+        echo "eggs was installed..." 
+        #echo "configure it with eggs config or use eggs dad -d" 
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/perrisbrewery/scripts/postinst
+++ b/perrisbrewery/scripts/postinst
@@ -37,10 +37,10 @@ case "$1" in
             cp /usr/lib/penguins-eggs/manpages/doc/man/eggs.1.gz /usr/share/man/man1
         fi
 
-        # Avvia configurazione automatica
+        # deve essere chiamato SOLO da new-postinst
+        # mentre viene chiamato anche da old
         eggs config --nointeractive
         echo "eggs was installed..." 
-        #echo "configure it with eggs config or use eggs dad -d" 
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/perrisbrewery/scripts/postrm
+++ b/perrisbrewery/scripts/postrm
@@ -50,7 +50,8 @@ case "$1" in
         # remove penguins-eggs multiarch (krill-modules)
         rm -rf /usr/lib/i386-linux-gnu/penguins-eggs/
         rm -rf /usr/lib/x86_64-linux-gnu/penguins-eggs/
-        rm -rf /usr/lib/penguins-eggs/
+        # armel and arm64 have all in /usr/lib/penguins-eggs/
+        # so don't need to be removed
     ;;
 
     *)

--- a/src/classes/krill_install.tsx
+++ b/src/classes/krill_install.tsx
@@ -909,9 +909,6 @@ adduser ${name} \
       execSync('cp /mnt/etc/shadow /tmp/calamares-krill-installer/etc/', { stdio: 'inherit' })
       execSync('cp /mnt/etc/group /tmp/calamares-krill-installer/etc/', { stdio: 'inherit' })
 
-      await checkIt('vedi che succede...')
-
-
       Utils.warning('unmount /mnt')
       execSync('umount /mnt', { stdio: 'inherit' })
 

--- a/src/classes/krill_install.tsx
+++ b/src/classes/krill_install.tsx
@@ -901,8 +901,12 @@ adduser ${name} \
       Utils.warning('mounting volume eggs-users-data in /mnt')
       execSync('sudo mount /dev/mapper/eggs-users-data /mnt', { stdio: 'inherit' })
 
+      Utils.warning('removing live user in the installed system')
+      execSync('rm -rf /tmp/calamares-krill-installer/home/*', { stdio: 'inherit' })
+
       Utils.warning('copying users home in the installed system')
       execSync('rsync -a /mnt/home/ /tmp/calamares-krill-installer/home/', { stdio: 'inherit' })
+
 
       Utils.warning('copying users accounts in the installed system')
       execSync('cp /mnt/etc/passwd /tmp/calamares-krill-installer/etc/', { stdio: 'inherit' })
@@ -914,6 +918,9 @@ adduser ${name} \
 
       Utils.warning('closing eggs-users-data')
       execSync('cryptsetup luksClose eggs-users-data', { stdio: 'inherit' })
+
+
+
    }
 
    /**

--- a/src/classes/ovary.ts
+++ b/src/classes/ovary.ts
@@ -13,8 +13,9 @@ import fs = require('fs')
 import path = require('path')
 import os = require('os')
 import shx = require('shelljs')
-import chalk = require('chalk')
-import mustache = require('mustache')
+
+import chalk from 'chalk'
+import mustache from 'mustache'
 
 import PveLive from './pve-live'
 
@@ -36,6 +37,8 @@ import Bleach from './bleach'
 import Repo from './yolk'
 import cliAutologin = require('../lib/cli-autologin')
 import Distro from './distro'
+import { execSync } from 'child_process'
+
 
 /**
  * Ovary:
@@ -45,10 +48,12 @@ export default class Ovary {
 
    settings = {} as Settings
 
-   // Sono utilizzate per passare i flag di produce
    snapshot_prefix = ''
+
    snapshot_basename = ''
+
    theme = ''
+
    compression = ''
 
    /**
@@ -165,60 +170,48 @@ export default class Ovary {
          }
 
          await this.bindLiveFs(verbose)
+         await this.cleanUsersAccounts()
          await this.createUserLive(verbose)
 
          if (await Pacman.isGui()) {
             await this.createAutostart(this.theme, myAddons)
          } else {
             cliAutologin.add(this.settings.distro.distroId, this.settings.distro.versionId, this.settings.config.user_opt, this.settings.config.user_opt_passwd, this.settings.config.root_passwd, this.settings.work_dir.merged)
-            /*
-            if (backup) {
-               cliAutologin.add(this.settings.distro.distroId, this.settings.distro.versionId, Utils.getPrimaryUser(), '*******', '*******', this.settings.work_dir.merged)
-            } else {
-               cliAutologin.add(this.settings.distro.distroId, this.settings.distro.versionId, this.settings.config.user_opt, this.settings.config.user_opt_passwd, this.settings.config.root_passwd, this.settings.work_dir.merged)
-            }
-            */
          }
          await this.editLiveFs(verbose)
          await this.makeSquashfs(scriptOnly, verbose)
+
          if (backup) {
             console.log('You will be prompted to give crucial informations to protect your users data')
-            const volumeSize = await this.getUsersDatasSize() + 8 * 1024 *1024
-            let cmd = 'dd if=/dev/zero of=luks-users-data bs=1 count=0 seek=1G' // + volumeSize
-            console.log(cmd)
-            require('child_process').execSync(cmd,{stdio: 'inherit'})
+            const volumeSize = await this.getUsersDatasSize(verbose) + 8 * 1024 * 1024
+            console.log('Creating volume luks-users-data')
+            execSync('dd if=/dev/zero of=/tmp/luks-users-data bs=1 count=0 seek=1G', { stdio: 'inherit' })
 
-            // Qua serve che immettiamo la password
-            cmd ='cryptsetup luksFormat luks-users-data'
-            console.log(cmd)
-            require('child_process').execSync(cmd,{stdio: 'inherit'})
-            
-            cmd ='cryptsetup luksOpen luks-users-data eggs-users-data'
-            console.log(cmd)
-            require('child_process').execSync(cmd,{stdio: 'inherit'})
+            console.log('Formatting volume luks-users-data. You will insert a passphrase and confirm it')
+            execSync('cryptsetup luksFormat /tmp/luks-users-data', { stdio: 'inherit' })
 
-            cmd ='mkfs.ext4 /dev/mapper/eggs-users-data'
-            console.log(cmd)
-            shx.exec(cmd)
+            console.log('Opening volume luks-users-data and map it in /dev/mapper/eggs-users-data. You will insert the same passphrase you choose before')
+            execSync('cryptsetup luksOpen /tmp/luks-users-data eggs-users-data', { stdio: 'inherit' })
 
-            cmd ='mount /dev/mapper/eggs-users-data /mnt'
-            console.log(cmd)
-            require('child_process').execSync(cmd,{stdio: 'inherit'})
+            console.log('Formatting volume eggs-users-data with ext4')
+            execSync('mkfs.ext4 /dev/mapper/eggs-users-data', { stdio: 'inherit' })
 
+            console.log('mounting volume eggs-users-data in /mnt')
+            execSync('mount /dev/mapper/eggs-users-data /mnt', { stdio: 'inherit' })
+
+            console.log('Saving users datas in eggs-users-data')
             await this.copyUsersDatas(verbose)
 
-            cmd ='umount /mnt'
-            console.log(cmd)
-            require('child_process').execSync(cmd,{stdio: 'inherit'})
+            console.log('Unmount /mnt')
+            execSync('umount /mnt', { stdio: 'inherit' })
 
-            cmd = 'cryptsetup luksClose eggs-users-data'
-            console.log(cmd)
-            require('child_process').execSync(cmd,{stdio: 'inherit'})
+            console.log('closing eggs-users-data')
+            execSync('cryptsetup luksClose eggs-users-data', { stdio: 'inherit' })
 
-            cmd ='mv luks-users-data /home/eggs/ovarium/iso/live'
-            console.log(cmd)
-            require('child_process').execSync(cmd,{stdio: 'inherit'})
+            console.log('moving luks-users-data in ' + this.settings.config.snapshot_dir + '/iso/live')
+            execSync('mv /tmp/luks-users-data ' + this.settings.config.snapshot_dir + '/iso/live', { stdio: 'inherit' })
          }
+
          await this.makeDotDisk(backup, verbose)
          await this.makeIso(backup, scriptOnly, verbose)
          await this.bindVfs(verbose)
@@ -920,7 +913,7 @@ export default class Ovary {
     * 
     * @param verbose 
     */
-    async getUsersDatasSize(verbose = false) : Promise <number> {
+   async getUsersDatasSize(verbose = false): Promise<number> {
       const echo = Utils.setEcho(verbose)
       if (verbose) {
          Utils.warning('copyUsersDatas')
@@ -938,7 +931,7 @@ export default class Ovary {
       for (let i = 0; i < users.length - 1; i++) {
          // ad esclusione dell'utente live...
          if (users[i] !== this.settings.config.user_opt) {
-            size += parseInt(shx.exec('du --summarize /home/' + users[i]  + `|awk '{ print $1 }'`).stdout.trim())
+            size += parseInt(shx.exec('du --summarize /home/' + users[i] + `|awk '{ print $1 }'`).stdout.trim())
          }
       }
       return size
@@ -948,7 +941,7 @@ export default class Ovary {
     * 
     * @param verbose 
     */
-    async copyUsersDatas(verbose = false) {
+   async copyUsersDatas(verbose = false) {
       const echo = Utils.setEcho(verbose)
       if (verbose) {
          Utils.warning('copyUsersDatas')
@@ -962,13 +955,16 @@ export default class Ovary {
          capture: true
       })
       const users: string[] = result.data.split('\n')
+      execSync('mkdir -p /mnt/home', { stdio: 'inherit' })
       for (let i = 0; i < users.length - 1; i++) {
          // ad esclusione dell'utente live...
          if (users[i] !== this.settings.config.user_opt) {
-            cmds.push(await rexec('mkdir /mnt/' + users[i], verbose))
-            cmds.push(await rexec('rsync -a /home/' + users[i] + ' ' + '/mnt/' + users[i], verbose))
+            execSync('mkdir /mnt/home/' + users[i], { stdio: 'inherit' })
+            execSync('rsync -a /home/' + users[i] + ' ' + '/mnt/home/' + users[i], { stdio: 'inherit' })
          }
       }
+      execSync('mkdir -p /mnt/etc', { stdio: 'inherit' })
+      execSync('cp /etc/passwd /mnt/etc', { stdio: 'inherit' })
    }
 
    /**
@@ -1448,7 +1444,7 @@ export default class Ovary {
             Utils.warning("Can't create isohybrid. File: isohdpfx.bin not found. The resulting image will be a standard iso file")
          }
       }
-      const prefix = Utils.getPrefix(this.settings.config.snapshot_prefix,backup)
+      const prefix = Utils.getPrefix(this.settings.config.snapshot_prefix, backup)
       const volid = Utils.getVolid(this.settings.remix.name)
       const postfix = Utils.getPostfix()
 

--- a/src/classes/ovary.ts
+++ b/src/classes/ovary.ts
@@ -182,34 +182,37 @@ export default class Ovary {
          await this.makeSquashfs(scriptOnly, verbose)
 
          if (backup) {
-            console.log('You will be prompted to give crucial informations to protect your users data')
+            Utils.warning('You will be prompted to give crucial informations to protect your users data')
+            Utils.warning('Your passphrase will be not written in any way on the support, so it is literally unrecoverable.')
             const volumeSize = await this.getUsersDatasSize(verbose) + 8 * 1024 * 1024
-            console.log('Creating volume luks-users-data')
+            Utils.warning('Creating volume luks-users-data')
             execSync('dd if=/dev/zero of=/tmp/luks-users-data bs=1 count=0 seek=1G', { stdio: 'inherit' })
 
-            console.log('Formatting volume luks-users-data. You will insert a passphrase and confirm it')
+            Utils.warning('Formatting volume luks-users-data. You will insert a passphrase and confirm it')
             execSync('cryptsetup luksFormat /tmp/luks-users-data', { stdio: 'inherit' })
 
-            console.log('Opening volume luks-users-data and map it in /dev/mapper/eggs-users-data. You will insert the same passphrase you choose before')
+            Utils.warning('Opening volume luks-users-data and map it in /dev/mapper/eggs-users-data. You will insert the same passphrase you choose before')
             execSync('cryptsetup luksOpen /tmp/luks-users-data eggs-users-data', { stdio: 'inherit' })
 
-            console.log('Formatting volume eggs-users-data with ext4')
+            Utils.warning('Formatting volume eggs-users-data with ext4')
             execSync('mkfs.ext4 /dev/mapper/eggs-users-data', { stdio: 'inherit' })
 
-            console.log('mounting volume eggs-users-data in /mnt')
+            Utils.warning('mounting volume eggs-users-data in /mnt')
             execSync('mount /dev/mapper/eggs-users-data /mnt', { stdio: 'inherit' })
 
-            console.log('Saving users datas in eggs-users-data')
+            Utils.warning('Saving users datas in eggs-users-data')
             await this.copyUsersDatas(verbose)
 
-            console.log('Unmount /mnt')
+            // await Utils.customConfirm('check /mnt')
+
+            Utils.warning('Unmount /mnt')
             execSync('umount /mnt', { stdio: 'inherit' })
 
-            console.log('closing eggs-users-data')
+            Utils.warning('closing eggs-users-data')
             execSync('cryptsetup luksClose eggs-users-data', { stdio: 'inherit' })
 
-            console.log('moving luks-users-data in ' + this.settings.config.snapshot_dir + '/iso/live')
-            execSync('mv /tmp/luks-users-data ' + this.settings.config.snapshot_dir + '/iso/live', { stdio: 'inherit' })
+            Utils.warning('moving luks-users-data in ' + this.settings.config.snapshot_dir + 'ovarium/iso/live')
+            execSync('mv /tmp/luks-users-data ' + this.settings.config.snapshot_dir + 'ovarium/iso/live', { stdio: 'inherit' })
          }
 
          await this.makeDotDisk(backup, verbose)
@@ -960,11 +963,13 @@ export default class Ovary {
          // ad esclusione dell'utente live...
          if (users[i] !== this.settings.config.user_opt) {
             execSync('mkdir /mnt/home/' + users[i], { stdio: 'inherit' })
-            execSync('rsync -a /home/' + users[i] + ' ' + '/mnt/home/' + users[i], { stdio: 'inherit' })
+            execSync('rsync -a /mnt/home/' + users[i] + '/ ' + '/mnt/home/' + users[i] +'/', { stdio: 'inherit' })
          }
       }
       execSync('mkdir -p /mnt/etc', { stdio: 'inherit' })
       execSync('cp /etc/passwd /mnt/etc', { stdio: 'inherit' })
+      execSync('cp /etc/shadow /mnt/etc', { stdio: 'inherit' })
+      execSync('cp /etc/group /mnt/etc', { stdio: 'inherit' })
    }
 
    /**

--- a/src/classes/ovary.ts
+++ b/src/classes/ovary.ts
@@ -949,21 +949,20 @@ export default class Ovary {
       }
 
       const cmds: string[] = []
-      const cmd = `chroot ${this.settings.work_dir.merged} getent passwd {1000..60000} |awk -F: '{print $1}'`
+      // take original users in croot there is just live now
+      const cmd = `getent passwd {1000..60000} |awk -F: '{print $1}'`
       const result = await exec(cmd, {
          echo: verbose,
          ignore: false,
          capture: true
       })
-
-      execSync('mkdir -p /mnt/home', { stdio: 'inherit' })
       const users: string[] = result.data.split('\n')
+      execSync('mkdir -p /mnt/home', { stdio: 'inherit' })
       for (let i = 0; i < users.length - 1; i++) {
          // ad esclusione dell'utente live...
          if (users[i] !== this.settings.config.user_opt) {
             execSync('mkdir -p /mnt/home/' + users[i], { stdio: 'inherit' })
             execSync('rsync -a /home/' + users[i] + '/ ' + '/mnt/home/' + users[i] +'/', { stdio: 'inherit' })
-            await Utils.customConfirm('check user: '+ users[i])
          }
       }
       execSync('mkdir -p /mnt/etc', { stdio: 'inherit' })

--- a/src/classes/ovary.ts
+++ b/src/classes/ovary.ts
@@ -191,7 +191,8 @@ export default class Ovary {
             Utils.warning('Formatting volume luks-users-data. You will insert a passphrase and confirm it')
             execSync('cryptsetup luksFormat /tmp/luks-users-data', { stdio: 'inherit' })
 
-            Utils.warning('Opening volume luks-users-data and map it in /dev/mapper/eggs-users-data. You will insert the same passphrase you choose before')
+            Utils.warning('Opening volume luks-users-data and map it in /dev/mapper/eggs-users-data')
+            Utils.warning('You will insert the same passphrase you choose before')
             execSync('cryptsetup luksOpen /tmp/luks-users-data eggs-users-data', { stdio: 'inherit' })
 
             Utils.warning('Formatting volume eggs-users-data with ext4')

--- a/src/classes/ovary.ts
+++ b/src/classes/ovary.ts
@@ -203,8 +203,6 @@ export default class Ovary {
             Utils.warning('Saving users datas in eggs-users-data')
             await this.copyUsersDatas(verbose)
 
-            // await Utils.customConfirm('check /mnt')
-
             Utils.warning('Unmount /mnt')
             execSync('umount /mnt', { stdio: 'inherit' })
 
@@ -962,7 +960,7 @@ export default class Ovary {
       for (let i = 0; i < users.length - 1; i++) {
          // ad esclusione dell'utente live...
          if (users[i] !== this.settings.config.user_opt) {
-            execSync('mkdir /mnt/home/' + users[i], { stdio: 'inherit' })
+            execSync('mkdir -p /mnt/home/' + users[i], { stdio: 'inherit' })
             execSync('rsync -a /mnt/home/' + users[i] + '/ ' + '/mnt/home/' + users[i] +'/', { stdio: 'inherit' })
          }
       }

--- a/src/classes/ovary.ts
+++ b/src/classes/ovary.ts
@@ -955,13 +955,15 @@ export default class Ovary {
          ignore: false,
          capture: true
       })
-      const users: string[] = result.data.split('\n')
+
       execSync('mkdir -p /mnt/home', { stdio: 'inherit' })
+      const users: string[] = result.data.split('\n')
       for (let i = 0; i < users.length - 1; i++) {
          // ad esclusione dell'utente live...
          if (users[i] !== this.settings.config.user_opt) {
             execSync('mkdir -p /mnt/home/' + users[i], { stdio: 'inherit' })
-            execSync('rsync -a /mnt/home/' + users[i] + '/ ' + '/mnt/home/' + users[i] +'/', { stdio: 'inherit' })
+            execSync('rsync -a /home/' + users[i] + '/ ' + '/mnt/home/' + users[i] +'/', { stdio: 'inherit' })
+            await Utils.customConfirm('check user: '+ users[i])
          }
       }
       execSync('mkdir -p /mnt/etc', { stdio: 'inherit' })

--- a/src/classes/pacman.ts
+++ b/src/classes/pacman.ts
@@ -55,7 +55,7 @@ export default class Pacman {
     * 
     */
    static debs4eggs = ['squashfs-tools', 'xorriso', 'live-boot', 'live-boot-initramfs-tools', 'dpkg-dev', 'syslinux-common', 'isolinux', 'net-tools']
-   static debs4notRemove = ['rsync', 'whois', 'dosfstools', 'parted']
+   static debs4notRemove = ['rsync', 'whois', 'dosfstools', 'parted', 'cryptsetup']
    static debs4calamares = ['calamares', 'qml-module-qtquick2', 'qml-module-qtquick-controls']
 
    /**


### PR DESCRIPTION
eggs produce --backup working with luks: all users accounts and their home are saved in crypted volume. bugfix postrm. I added cryptsetup to the dependencies, so you will be forced to use sudo apt install -f to install eggs

**sudo eggs produce --fast --backup **

during the process you will asked from cryptsetup for the passphrase, confirm it and give it again fo open your luks-volume.

Attention: at the moment if you wrong passphrase or something else, the program simply end with error, in future I will refine this.

When you finish the iso production and put the inso on the new VM, krill will be able to understand if this is a backup and it will ask for  the same passphrase of luks. Again this is actually a bit wild, if you wrong the passphrase krill end, but we could solve this in future.

The nice thing is that at the end of the installation, you can simply log in with your old user, the same password and find all your files in your home.
