### PR TITLE
8.0.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ npm install -g penguins-eggs
 $ eggs COMMAND
 running command...
 $ eggs (-v|--version|version)
-penguins-eggs/8.0.28 linux-x64 node-v8.17.0
+penguins-eggs/8.0.29 linux-x64 node-v8.17.0
 $ eggs --help [COMMAND]
 USAGE
   $ eggs COMMAND
@@ -156,7 +156,7 @@ ALIASES
   $ eggs adjust
 ```
 
-_See code: [src/commands/adapt.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.28/src/commands/adapt.ts)_
+_See code: [src/commands/adapt.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.29/src/commands/adapt.ts)_
 
 ## `eggs autocomplete [SHELL]`
 
@@ -205,7 +205,7 @@ EXAMPLES
   install calamares and create it's configuration's files
 ```
 
-_See code: [src/commands/calamares.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.28/src/commands/calamares.ts)_
+_See code: [src/commands/calamares.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.29/src/commands/calamares.ts)_
 
 ## `eggs config`
 
@@ -229,7 +229,7 @@ EXAMPLE
   Configure and install prerequisites deb packages to run it
 ```
 
-_See code: [src/commands/config.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.28/src/commands/config.ts)_
+_See code: [src/commands/config.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.29/src/commands/config.ts)_
 
 ## `eggs dad`
 
@@ -246,7 +246,7 @@ OPTIONS
   -v, --verbose
 ```
 
-_See code: [src/commands/dad.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.28/src/commands/dad.ts)_
+_See code: [src/commands/dad.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.29/src/commands/dad.ts)_
 
 ## `eggs export:deb`
 
@@ -266,7 +266,7 @@ OPTIONS
   --i386       export i386 arch
 ```
 
-_See code: [src/commands/export/deb.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.28/src/commands/export/deb.ts)_
+_See code: [src/commands/export/deb.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.29/src/commands/export/deb.ts)_
 
 ## `eggs export:docs`
 
@@ -280,7 +280,7 @@ OPTIONS
   -h, --help  show CLI help
 ```
 
-_See code: [src/commands/export/docs.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.28/src/commands/export/docs.ts)_
+_See code: [src/commands/export/docs.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.29/src/commands/export/docs.ts)_
 
 ## `eggs export:iso`
 
@@ -296,7 +296,7 @@ OPTIONS
   -h, --help    show CLI help
 ```
 
-_See code: [src/commands/export/iso.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.28/src/commands/export/iso.ts)_
+_See code: [src/commands/export/iso.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.29/src/commands/export/iso.ts)_
 
 ## `eggs help [COMMAND]`
 
@@ -328,7 +328,7 @@ OPTIONS
   -v, --verbose
 ```
 
-_See code: [src/commands/info.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.28/src/commands/info.ts)_
+_See code: [src/commands/info.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.29/src/commands/info.ts)_
 
 ## `eggs install`
 
@@ -352,7 +352,7 @@ EXAMPLE
   Install the system using GUI or CLI installer
 ```
 
-_See code: [src/commands/install.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.28/src/commands/install.ts)_
+_See code: [src/commands/install.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.29/src/commands/install.ts)_
 
 ## `eggs kill`
 
@@ -371,7 +371,7 @@ EXAMPLE
   kill the eggs/free the nest
 ```
 
-_See code: [src/commands/kill.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.28/src/commands/kill.ts)_
+_See code: [src/commands/kill.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.29/src/commands/kill.ts)_
 
 ## `eggs mom`
 
@@ -385,7 +385,7 @@ OPTIONS
   -h, --help  show CLI help
 ```
 
-_See code: [src/commands/mom.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.28/src/commands/mom.ts)_
+_See code: [src/commands/mom.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.29/src/commands/mom.ts)_
 
 ## `eggs produce`
 
@@ -446,7 +446,7 @@ EXAMPLES
   in /home/eggs/ovarium and you can customize all you need
 ```
 
-_See code: [src/commands/produce.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.28/src/commands/produce.ts)_
+_See code: [src/commands/produce.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.29/src/commands/produce.ts)_
 
 ## `eggs remove`
 
@@ -470,7 +470,7 @@ EXAMPLES
   remove eggs, eggs configurations, packages prerequisites
 ```
 
-_See code: [src/commands/remove.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.28/src/commands/remove.ts)_
+_See code: [src/commands/remove.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.29/src/commands/remove.ts)_
 
 ## `eggs tools:clean`
 
@@ -488,7 +488,7 @@ ALIASES
   $ eggs clean
 ```
 
-_See code: [src/commands/tools/clean.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.28/src/commands/tools/clean.ts)_
+_See code: [src/commands/tools/clean.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.29/src/commands/tools/clean.ts)_
 
 ## `eggs tools:locales`
 
@@ -504,7 +504,7 @@ OPTIONS
   -v, --verbose    verbose
 ```
 
-_See code: [src/commands/tools/locales.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.28/src/commands/tools/locales.ts)_
+_See code: [src/commands/tools/locales.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.29/src/commands/tools/locales.ts)_
 
 ## `eggs tools:skel`
 
@@ -527,7 +527,7 @@ EXAMPLE
   desktop configuration of user mauro will get used as default
 ```
 
-_See code: [src/commands/tools/skel.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.28/src/commands/tools/skel.ts)_
+_See code: [src/commands/tools/skel.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.29/src/commands/tools/skel.ts)_
 
 ## `eggs tools:stat`
 
@@ -546,7 +546,7 @@ ALIASES
   $ eggs stat
 ```
 
-_See code: [src/commands/tools/stat.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.28/src/commands/tools/stat.ts)_
+_See code: [src/commands/tools/stat.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.29/src/commands/tools/stat.ts)_
 
 ## `eggs tools:yolk`
 
@@ -564,7 +564,7 @@ EXAMPLE
   $ eggs yolk -v
 ```
 
-_See code: [src/commands/tools/yolk.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.28/src/commands/tools/yolk.ts)_
+_See code: [src/commands/tools/yolk.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.29/src/commands/tools/yolk.ts)_
 
 ## `eggs update`
 
@@ -586,7 +586,7 @@ EXAMPLE
   update/upgrade the penguin's eggs tool
 ```
 
-_See code: [src/commands/update.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.28/src/commands/update.ts)_
+_See code: [src/commands/update.ts](https://github.com/pieroproietti/penguins-eggs/blob/v8.0.29/src/commands/update.ts)_
 <!-- commandsstop -->
 
 # Terminal samples

--- a/addons/pve/theme/calamares/modules/partition.yml
+++ b/addons/pve/theme/calamares/modules/partition.yml
@@ -5,7 +5,7 @@
 # distributions (Fedora, Debian, Manjaro, etc.) use /boot/efi, others (KaOS,
 # etc.) use just /boot.
 #
-# Defaults to "/boot/efi", may be empty (but weird effects ensue)
+# Defaults to "/boot/efi", may be empty (but weird effects ensure)
 efiSystemPartition:     "/boot/efi"
 
 # This optional setting specifies the size of the EFI system partition.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "penguins-eggs",
-  "version": "8.0.28",
+  "version": "8.0.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "penguins-eggs",
   "shortName": "eggs",
   "description": "Perri's Brewery edition: remaster your system and distribuite it",
-  "version": "8.0.28",
+  "version": "8.0.29",
   "author": "Piero Proietti @pieroproietti",
   "bin": {
     "eggs": "bin/run"

--- a/src/classes/incubation/branding.ts
+++ b/src/classes/incubation/branding.ts
@@ -28,15 +28,16 @@ export function branding(remix: IRemix, distro: IDistro, brand = '', verbose = f
    const shortVersion = version
    const versionedName = remix.fullname  + ' ('+ version + ')' // Questa la mette nella descrizione andrebbe aggiunta la versione dal nome della iso
    const shortVersionedName = remix.versionName + ' ' + version
-   //let bootloaderEntryName = distro.distroId
-   let bootloaderEntryName = distro.distroId // perchè avevo messo remix.fullname?
 
-   // Necessario: Devuan e LMDE devono avere EFI=Debian
+   let bootloaderEntryName = distro.distroId
+
+   // Necessario: Devuan e LMDE devono avere EFI=Debian altrimenti non funziona EFI
    if (bootloaderEntryName === 'Devuan') {
       bootloaderEntryName = 'Debian'
    } else if (bootloaderEntryName === 'LMDE') {
       bootloaderEntryName = 'Debian'
    }
+
    const productUrl = homeUrl
    const releaseNotesUrl = 'https://github.com/pieroproietti/penguins-eggs/changelog.md'
    const productLogo = `${remix.branding}-logo.png`

--- a/src/classes/krill_install.tsx
+++ b/src/classes/krill_install.tsx
@@ -20,6 +20,7 @@ import shx = require('shelljs')
 import Utils from './utils'
 import cliAutologin = require('../lib/cli-autologin')
 const exec = require('../lib/utils').exec
+import {IWelcome, ILocation, IKeyboard, IPartitions, IUsers} from '../interfaces/i-krill'
 
 import { execSync } from 'child_process'
 
@@ -54,6 +55,7 @@ import { execSync } from 'child_process'
       - umount
  */
 
+// interface solo per hatching
 interface ICalamaresModule {
    type: string,
    name: string,
@@ -62,35 +64,6 @@ interface ICalamaresModule {
    timeout: number
 }
 
-
-interface ILocation {
-   language: string,
-   region: string,
-   zone: string
-}
-
-interface IKeyboard {
-   keyboardModel: string,
-   keyboardLayout: string,
-   keyboardVariant: string
-}
-
-interface IPartitions {
-   installationDevice: string,
-   filesystemType: string,
-   userSwapChoice: string
-}
-
-interface IUsers {
-   name: string,
-   fullname: string,
-   password: string,
-   rootPassword: string,
-   autologin: boolean,
-   hostname: string
-}
-
-// Solo per hatching
 interface IHost {
    name: string
    domain: string

--- a/src/classes/krill_install.tsx
+++ b/src/classes/krill_install.tsx
@@ -865,10 +865,6 @@ adduser ${name} \
     * mkfs
     */
    private async mkfs(): Promise<boolean> {
-      // this.disk.fsType = partitions.filesystemType
-      // this.disk.installationDevice = partitions.installationDevice
-      // this.disk.partionType = 'simple'
-
       const echo = { echo: false, ignore: false }
 
       const result = true
@@ -884,7 +880,6 @@ adduser ${name} \
          }
          await exec('mke2fs -Ft ' + this.devices.boot.fsType + ' ' + this.devices.boot.name + this.toNull, echo)
       }
-
 
       if (this.devices.root.name !== 'none') {
          await exec('mke2fs -Ft ' + this.devices.root.fsType + ' ' + this.devices.root.name + this.toNull, echo)
@@ -1033,7 +1028,7 @@ adduser ${name} \
       if (p.installationMode === 'standard' && !this.efi) {
 
          /**
-          * formattazione standard, non EFI working
+          * formattazione standard, BIOS working
           */
          await exec('parted --script ' + p.installationDevice + ' mklabel msdos' + this.toNull, echo)
          await exec('parted --script --align optimal ' + p.installationDevice + ' mkpart primary 1MiB 95%' + this.toNull, echo)
@@ -1053,10 +1048,10 @@ adduser ${name} \
          retVal = true
 
       } else if (p.installationMode === 'standard' && this.efi) {
-
          /**
           * formattazione standard, EFI NOT working
           */
+
          await exec('parted --script ' + p.installationDevice + ' mklabel gpt mkpart primary 0% 1% mkpart primary 1% 95% mkpart primary linux-swap 95% 100%' + this.toNull, echo)
          await exec('parted --script ' + p.installationDevice + ' set 1 boot on' + this.toNull, echo)
          await exec('parted --script ' + p.installationDevice + ' set 1 esp on' + this.toNull, echo)
@@ -1075,7 +1070,7 @@ adduser ${name} \
          this.devices.swap.fsType = 'swap'
 
          retVal = true
-         
+
       } else if (p.installationMode === 'full-encrypted' && !this.efi) {
          /**
           * formattazione full-encrypted, BIOS standard
@@ -1087,10 +1082,10 @@ adduser ${name} \
           */
 
       } else if (p.installationMode === 'lvm2' && !this.efi) {
-
          /**
          * LVM2, non EFI PROXMOX-VE
          */
+
          await exec(`parted --script ${p.installationDevice} mklabel msdos`)
 
          // Creo partizioni

--- a/src/classes/krill_install_compare.tsx
+++ b/src/classes/krill_install_compare.tsx
@@ -115,7 +115,7 @@ export default class Hatching {
 
    installer = {} as IInstaller
 
-   installTarget = '/tmp/calamares-krill-installer'
+   installTarget = '/tmp/calamares-krill-root'
 
    verbose = false
 
@@ -902,16 +902,16 @@ adduser ${name} \
       execSync('sudo mount /dev/mapper/eggs-users-data /mnt', { stdio: 'inherit' })
 
       Utils.warning('removing live user in the installed system')
-      execSync('rm -rf /tmp/calamares-krill-installer/home/*', { stdio: 'inherit' })
+      execSync('rm -rf /tmp/calamares-krill-root/home/*', { stdio: 'inherit' })
 
       Utils.warning('copying users home in the installed system')
-      execSync('rsync -a /mnt/home/ /tmp/calamares-krill-installer/home/', { stdio: 'inherit' })
+      execSync('rsync -a /mnt/home/ /tmp/calamares-krill-root/home/', { stdio: 'inherit' })
 
 
       Utils.warning('copying users accounts in the installed system')
-      execSync('cp /mnt/etc/passwd /tmp/calamares-krill-installer/etc/', { stdio: 'inherit' })
-      execSync('cp /mnt/etc/shadow /tmp/calamares-krill-installer/etc/', { stdio: 'inherit' })
-      execSync('cp /mnt/etc/group /tmp/calamares-krill-installer/etc/', { stdio: 'inherit' })
+      execSync('cp /mnt/etc/passwd /tmp/calamares-krill-root/etc/', { stdio: 'inherit' })
+      execSync('cp /mnt/etc/shadow /tmp/calamares-krill-root/etc/', { stdio: 'inherit' })
+      execSync('cp /mnt/etc/group /tmp/calamares-krill-root/etc/', { stdio: 'inherit' })
 
       Utils.warning('unmount /mnt')
       execSync('umount /mnt', { stdio: 'inherit' })

--- a/src/classes/krill_prepare.tsx
+++ b/src/classes/krill_prepare.tsx
@@ -22,6 +22,7 @@ import selectRegions from '../lib/select_regions'
 import selectZones from '../lib/select_zones'
 
 import selectInstallationDevice from '../lib/select_installation_device'
+import selectInstallationMode from '../lib/select_installation_mode'
 import selectUserSwapChoice from '../lib/select_user_swap_choice'
 import selectFileSystemType from '../lib/select_filesystem_type'
 
@@ -153,26 +154,32 @@ export default class Krill {
     let installationMode = 'standard'
     let filesystemType = 'ext4'
     let userSwapChoice = 'small'
+
     let partitionsElem: JSX.Element
     while (true) {
-      partitionsElem = <Partitions installationDevice={installationDevice} filesystemType={filesystemType} userSwapChoice={userSwapChoice} />
+      partitionsElem = <Partitions installationDevice={installationDevice} installationMode={installationMode} filesystemType={filesystemType} userSwapChoice={userSwapChoice} />
       if (await confirm(partitionsElem, "Confirm Partitions datas?")) {
         break
       } else {
         installationDevice = ''
+        installationMode = ''
         filesystemType = ''
         userSwapChoice = ''
       }
 
-      partitionsElem = <Partitions installationDevice={installationDevice} filesystemType={filesystemType} userSwapChoice={userSwapChoice} />
+      partitionsElem = <Partitions installationDevice={installationDevice} installationMode={installationMode} filesystemType={filesystemType} userSwapChoice={userSwapChoice} />
       redraw(partitionsElem)
       installationDevice = await selectInstallationDevice()
 
-      partitionsElem = <Partitions installationDevice={installationDevice} filesystemType={filesystemType} userSwapChoice={userSwapChoice} />
+      partitionsElem = <Partitions installationDevice={installationDevice} installationMode={installationMode} filesystemType={filesystemType} userSwapChoice={userSwapChoice} />
+      redraw(partitionsElem)
+      installationMode = await selectInstallationMode()
+
+      partitionsElem = <Partitions installationDevice={installationDevice} installationMode={installationMode} filesystemType={filesystemType} userSwapChoice={userSwapChoice} />
       redraw(partitionsElem)
       filesystemType = await selectFileSystemType()
 
-      partitionsElem = <Partitions installationDevice={installationDevice} filesystemType={filesystemType} userSwapChoice={userSwapChoice} />
+      partitionsElem = <Partitions installationDevice={installationDevice} installationMode={installationMode} filesystemType={filesystemType} userSwapChoice={userSwapChoice} />
       redraw(partitionsElem)
       userSwapChoice = await selectUserSwapChoice()
 

--- a/src/classes/krill_prepare.tsx
+++ b/src/classes/krill_prepare.tsx
@@ -43,38 +43,8 @@ import getDns from '../lib/get_dns'
 import Hatching from './krill_install'
 
 import { INet } from '../interfaces'
-import { getDefaultSettings } from 'http2';
+import {IWelcome, ILocation, IKeyboard, IPartitions, IUsers} from '../interfaces/i-krill'
 
-interface IWelcome {
-  language: string
-}
-
-interface ILocation {
-  language: string,
-  region: string,
-  zone: string
-}
-
-interface IKeyboard {
-  keyboardModel: string,
-  keyboardLayout: string,
-  keyboardVariant: string
-}
-
-interface IPartitions {
-  installationDevice: string,
-  filesystemType: string,
-  userSwapChoice: string
-}
-
-interface IUsers {
-  name: string,
-  fullname: string,
-  password: string,
-  rootPassword: string,
-  autologin: boolean,
-  hostname: string
-}
 
 export default class Krill {
 
@@ -180,6 +150,7 @@ export default class Krill {
   */
   async partitions(): Promise<IPartitions> {
     let installationDevice = '/dev/sda'
+    let installationMode = 'standard'
     let filesystemType = 'ext4'
     let userSwapChoice = 'small'
     let partitionsElem: JSX.Element
@@ -208,6 +179,7 @@ export default class Krill {
     }
     return {
       installationDevice: installationDevice,
+      installationMode: installationMode,
       filesystemType: filesystemType,
       userSwapChoice: userSwapChoice
     }

--- a/src/classes/ovary.ts
+++ b/src/classes/ovary.ts
@@ -1256,9 +1256,6 @@ export default class Ovary {
       shx.mkdir('-p', `./boot/grub/${Utils.machineUEFI()}`)
       shx.mkdir('-p', './efi/boot')
 
-      // copy splash
-      //shx.cp(path.resolve(__dirname, '../../assets/penguins-eggs-splash.png'), `${this.settings.efi_work}/boot/grub/spash.png`)
-
       // second grub.cfg file
       let cmd = `for i in $(ls /usr/lib/grub/${Utils.machineUEFI()}|grep part_|grep .mod|sed \'s/.mod//\'); do echo "insmod $i" >> boot/grub/${Utils.machineUEFI()}/grub.cfg; done`
       await exec(cmd, echo)

--- a/src/classes/ovary.ts
+++ b/src/classes/ovary.ts
@@ -201,7 +201,14 @@ export default class Ovary {
             if (volumeSize < minimunSize) {
                volumeSize = minimunSize
             }
-            volumeSize *= 1.10 // add 10% space until 1GB, with 2GB 4% is enought
+
+            if (volumeSize < 536870912) { // 512MB 536,870,912
+               volumeSize *= 1.15 // add 15%
+            } else if (volumeSize > 536870912 && (volumeSize < 1073741824)) { // 1GB 1,073,741,824
+               volumeSize *= 1.10 // add 10%
+            } else if (volumeSize > 1073741824) { // 1GB 1,073,741,824
+               volumeSize *= 1.05 // add 5% 
+            }
 
             Utils.warning('Creating volume luks-users-data of ' + Utils.formatBytes(volumeSize, 0))
             execSync('dd if=/dev/zero of=/tmp/luks-users-data bs=1 count=0 seek=' + Utils.formatBytes(volumeSize, 0) + this.toNull, { stdio: 'inherit' })
@@ -221,6 +228,9 @@ export default class Ovary {
 
             Utils.warning('Saving users datas in eggs-users-data')
             await this.copyUsersDatas(verbose)
+
+            const bytesUsed = parseInt(shx.exec(`du -b --summarize /mnt |awk '{ print $1 }'`, { silent: true }).stdout.trim())
+            Utils.warning('We used ' + Utils.formatBytes(bytesUsed, 0) + ' on ' + Utils.formatBytes(volumeSize, 0) + ' in volume luks-users-data')
 
             Utils.warning('Unmount /mnt')
             execSync('umount /mnt', { stdio: 'inherit' })

--- a/src/classes/xdg.ts
+++ b/src/classes/xdg.ts
@@ -99,8 +99,13 @@ export default class Xdg {
 
          // sddm
          if (Pacman.packageIsInstalled('sddm')) {
+            // cat /etc/sddm.conf 
+            // Autologin]
+            // User=artisan
+            // Session=plasma.desktop
             const fileConf = `${chroot}/etc/sddm.conf`
             if (fs.existsSync(fileConf)) {
+               // it work 15/7/2021 but don't log... why????
                shx.sed('-i', `User=${olduser}`, `User=${newuser}`, fileConf)
             } else {
                const dirConf = `${chroot}/etc/sddm.conf.d`

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -39,7 +39,7 @@ export default class Install extends Command {
       }
 
       if (Utils.isRoot(this.id)) {
-         if (!Utils.isLive()) {
+         if (Utils.isLive()) {
             if (Pacman.packageIsInstalled('calamares') && Pacman.guiEnabled() && !flags.cli) {
                shx.exec('calamares')
             } else {

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -39,7 +39,7 @@ export default class Install extends Command {
       }
 
       if (Utils.isRoot(this.id)) {
-         if (Utils.isLive()) {
+         if (!Utils.isLive()) {
             if (Pacman.packageIsInstalled('calamares') && Pacman.guiEnabled() && !flags.cli) {
                shx.exec('calamares')
             } else {

--- a/src/components/partitions.tsx
+++ b/src/components/partitions.tsx
@@ -38,6 +38,10 @@ export default function Partitions({ installationDevice, installationMode, files
     * finestra with=59
     */
 
+    let bios = 'standard'
+    if (fs.existsSync('/sys/firmware/efi/efivars')) {
+        bios = 'UEFI'
+    }
     let partitions = {} as IPartitions
     if (fs.existsSync(configRoot + 'modules/partition.conf')) {
         partitions = yaml.load(fs.readFileSync(configRoot + 'modules/partition.conf', 'utf-8')) as unknown as IPartitions
@@ -60,6 +64,7 @@ export default function Partitions({ installationDevice, installationMode, files
                                 <Text underline={true}>erase disk:</Text><Text> this will </Text><Text color="red">delete </Text><Text>all data currently</Text>
                             </Box>
                             <Box><Text>present on the selected storage device</Text></Box>
+                            <Box><Text>BIOS: </Text><Text color="cyan">{bios}</Text></Box>
                             <Newline />
                             <Box><Text>Installation device: </Text><Text color="cyan">{installationDevice}</Text></Box>
                             <Box><Text>Installation mode: </Text><Text color="cyan">{installationMode}</Text></Box>

--- a/src/components/partitions.tsx
+++ b/src/components/partitions.tsx
@@ -12,12 +12,13 @@ import { ISettings, IBranding, IPartitions } from '../interfaces'
 
 type partitionsProps = {
     installationDevice?: string,
+    installationMode?: string,
     filesystemType?: string,
     userSwapChoice?: string
 }
 
 
-export default function Partitions({ installationDevice, filesystemType, userSwapChoice }: partitionsProps) {
+export default function Partitions({ installationDevice, installationMode, filesystemType, userSwapChoice }: partitionsProps) {
     let installer = 'krill'
     let productName = 'unknown'
     let version = 'x.x.x'
@@ -61,6 +62,7 @@ export default function Partitions({ installationDevice, filesystemType, userSwa
                             <Box><Text>present on the selected storage device</Text></Box>
                             <Newline />
                             <Box><Text>Installation device: </Text><Text color="cyan">{installationDevice}</Text></Box>
+                            <Box><Text>Installation mode: </Text><Text color="cyan">{installationMode}</Text></Box>
                             <Box><Text>Filesystem: </Text><Text color="cyan">{filesystemType}</Text></Box>
                             <Box><Text>User swap choice: : </Text><Text color="cyan">{userSwapChoice}</Text></Box>
                         </Box>

--- a/src/interfaces/i-krill.ts
+++ b/src/interfaces/i-krill.ts
@@ -29,3 +29,12 @@ export interface IUsers {
    autologin: boolean,
    hostname: string
 }
+
+// interface solo per hatching
+export interface ICalamaresModule {
+   type: string,
+   name: string,
+   interface: string,
+   command: string,
+   timeout: number
+}

--- a/src/interfaces/i-krill.ts
+++ b/src/interfaces/i-krill.ts
@@ -1,0 +1,31 @@
+export interface IWelcome {
+   language: string
+}
+
+export interface ILocation {
+   language: string,
+   region: string,
+   zone: string
+ }
+
+export interface IKeyboard {
+   keyboardModel: string,
+   keyboardLayout: string,
+   keyboardVariant: string
+}
+
+export interface IPartitions {
+   installationDevice: string,
+   installationMode: string,
+   filesystemType: string,
+   userSwapChoice: string
+}
+
+export interface IUsers {
+   name: string,
+   fullname: string,
+   password: string,
+   rootPassword: string,
+   autologin: boolean,
+   hostname: string
+}

--- a/src/lib/select_installation_mode.ts
+++ b/src/lib/select_installation_mode.ts
@@ -1,0 +1,24 @@
+'use strict'
+import inquirer = require('inquirer')
+import shx from 'shelljs'
+
+export default async function selectInstallationMode(): Promise<string> {
+
+   const modes = ['standard', 'full-encrypted']
+
+   const questions: Array<Record<string, any>> = [
+      {
+         type: 'list',
+         name: 'installationMode',
+         message: 'Select the installation mode: ',
+         choices: modes
+      }
+   ]
+
+   return new Promise(function (resolve) {
+
+      inquirer.prompt(questions).then(function (options) {
+        resolve(options.installationMode)
+      })
+    })
+}

--- a/src/lib/select_user_swap_choice.ts
+++ b/src/lib/select_user_swap_choice.ts
@@ -9,7 +9,7 @@ export default async function selectUserSwapChoice(): Promise<string> {
 
    let partitions = {} as IPartitions
    if (fs.existsSync('/etc/calamares/modules/partition.conf')) {
-      partitions = yaml.load(fs.readFileSync('c', 'utf-8')) as unknown as IPartitions
+      partitions = yaml.load(fs.readFileSync('/etc/calamares/modules/partition.conf', 'utf-8')) as unknown as IPartitions
    } else {
       partitions.userSwapChoices = ['none', 'small', 'suspend', 'file']
       partitions.initialSwapChoice = 'small'


### PR DESCRIPTION
After long debug, we finally understood why system installed with krill don't worked with UEFI. 
      /**
       * I know, that's very old thread, but maybe will help for someone. 
       * Most guides suggest the same solution to mount virtual filesystems before chroot:
       * for i in /dev /dev/pts /proc /sys /run; do sudo mount -B $i /mnt$i; done
       * But now (maybe related to efivars/efivarfs changes) this loop skips one very special sub-mountpoint 
       * - /sys/firmware/efi/efivars and efibootmgr/grub fails.
       * 
       * https://unix.stackexchange.com/questions/91620/efi-variables-are-not-supported-on-this-system
       */

Thanx a lot Ted 

https://unix.stackexchange.com/users/24024/ted
