### PR TITLE
ElementaryOS an Ubuntu focal deriveted

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ $ npm install -g penguins-eggs
 $ eggs COMMAND
 running command...
 $ eggs (--version|-v)
-penguins-eggs/9.0.5 linux-x64 node-v16.13.2
+penguins-eggs/9.0.6 linux-x64 node-v16.13.2
 $ eggs --help [COMMAND]
 USAGE
   $ eggs COMMAND
@@ -166,7 +166,7 @@ ALIASES
   $ eggs adjust
 ```
 
-_See code: [src/commands/adapt.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.5/src/commands/adapt.ts)_
+_See code: [src/commands/adapt.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.6/src/commands/adapt.ts)_
 
 ## `eggs autocomplete [SHELL]`
 
@@ -212,7 +212,7 @@ DESCRIPTION
   bro: waydroid helper
 ```
 
-_See code: [src/commands/bro.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.5/src/commands/bro.ts)_
+_See code: [src/commands/bro.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.6/src/commands/bro.ts)_
 
 ## `eggs calamares`
 
@@ -241,7 +241,7 @@ EXAMPLES
   install calamares and create it's configuration's files
 ```
 
-_See code: [src/commands/calamares.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.5/src/commands/calamares.ts)_
+_See code: [src/commands/calamares.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.6/src/commands/calamares.ts)_
 
 ## `eggs config`
 
@@ -268,7 +268,7 @@ EXAMPLES
   Configure and install prerequisites deb packages to run it
 ```
 
-_See code: [src/commands/config.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.5/src/commands/config.ts)_
+_See code: [src/commands/config.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.6/src/commands/config.ts)_
 
 ## `eggs dad`
 
@@ -288,7 +288,7 @@ DESCRIPTION
   ask help from daddy - configuration helper
 ```
 
-_See code: [src/commands/dad.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.5/src/commands/dad.ts)_
+_See code: [src/commands/dad.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.6/src/commands/dad.ts)_
 
 ## `eggs export deb`
 
@@ -379,7 +379,7 @@ DESCRIPTION
   re-thinking for a different approach to CLI
 ```
 
-_See code: [src/commands/info.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.5/src/commands/info.ts)_
+_See code: [src/commands/info.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.6/src/commands/info.ts)_
 
 ## `eggs install`
 
@@ -406,7 +406,7 @@ EXAMPLES
   Install the system using GUI or CLI installer
 ```
 
-_See code: [src/commands/install.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.5/src/commands/install.ts)_
+_See code: [src/commands/install.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.6/src/commands/install.ts)_
 
 ## `eggs kill`
 
@@ -428,7 +428,7 @@ EXAMPLES
   kill the eggs/free the nest
 ```
 
-_See code: [src/commands/kill.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.5/src/commands/kill.ts)_
+_See code: [src/commands/kill.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.6/src/commands/kill.ts)_
 
 ## `eggs mom`
 
@@ -445,7 +445,7 @@ DESCRIPTION
   ask for mommy - gui helper
 ```
 
-_See code: [src/commands/mom.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.5/src/commands/mom.ts)_
+_See code: [src/commands/mom.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.6/src/commands/mom.ts)_
 
 ## `eggs produce`
 
@@ -510,7 +510,7 @@ EXAMPLES
   in /home/eggs/ovarium and you can customize all you need
 ```
 
-_See code: [src/commands/produce.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.5/src/commands/produce.ts)_
+_See code: [src/commands/produce.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.6/src/commands/produce.ts)_
 
 ## `eggs remove`
 
@@ -540,7 +540,7 @@ EXAMPLES
   remove eggs, eggs configurations, packages dependencies
 ```
 
-_See code: [src/commands/remove.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.5/src/commands/remove.ts)_
+_See code: [src/commands/remove.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.6/src/commands/remove.ts)_
 
 ## `eggs tools clean`
 
@@ -663,7 +663,7 @@ EXAMPLES
   update/upgrade the penguin's eggs tool
 ```
 
-_See code: [src/commands/update.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.5/src/commands/update.ts)_
+_See code: [src/commands/update.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.6/src/commands/update.ts)_
 
 ## `eggs version`
 

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,9 @@ You can follow the project also consulting the [commit history](https://github.c
 ## Changelog
 Versions are listed on reverse order, the first is the last one.
 
+### eggs-9.0.6
+Added Elemantary jolnir
+
 ### eggs-9.0.5
 Added bash/zsh autocomplete, manpages and post_remove in manjaro, added zsh autocomplete in Debian families, updated oclif: removed sha, insert sudo
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "penguins-eggs",
-    "version": "9.0.5",
+    "version": "9.0.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "penguins-eggs",
-            "version": "9.0.5",
+            "version": "9.0.6",
             "license": "MIT",
             "dependencies": {
                 "@oclif/core": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "penguins-eggs",
     "description": "Perri's Brewery edition: remaster your system and distribuite it",
-    "version": "9.0.5",
+    "version": "9.0.6",
     "author": "Piero Proietti @pieroproietti",
     "bin": {
         "eggs": "bin/run"

--- a/perrisbrewery/scripts/postinst
+++ b/perrisbrewery/scripts/postinst
@@ -21,10 +21,17 @@ set -e
 case "$1" in
     configure)
 
-        # Adding bash-completion for eggs
+        # Adding bash-completion Debian/Devuan/Ubuntu /etc/bash_completion.d/
         if [ -d "/etc/bash_completion.d/" ]; then
             if [ -f "/usr/lib/penguins-eggs/scripts/eggs.bash" ]; then
                 cp /usr/lib/penguins-eggs/scripts/eggs.bash /etc/bash_completion.d/
+            fi
+        fi    
+
+        # Adding bash-completion elementary /usr/share/bash-completion/completions/
+        if [ -d "/usr/share/bash-completion/completions//" ]; then
+            if [ -f "/usr/lib/penguins-eggs/scripts/eggs.bash" ]; then
+                cp /usr/lib/penguins-eggs/scripts/eggs.bash /usr/share/bash-completion/completions/
             fi
         fi    
 

--- a/sourceforge/files/iso/elementary/README.md
+++ b/sourceforge/files/iso/elementary/README.md
@@ -21,7 +21,7 @@ All ISOs include eggs, you can udate it with: ```sudo eggs update```.
 
 # Elementary 
 
-[Elementary]https://elementary.io/) The thoughtful, capable, and ethical replacement for Windows and macOS.
+[Elementary](https://elementary.io/) The thoughtful, capable, and ethical replacement for Windows and macOS.
 
 * **egg-of-elementary-jolnir-pantheon** - remastered version from lementaryos-6.1-stable.20211218-rc.iso 
 

--- a/sourceforge/files/iso/elementary/README.md
+++ b/sourceforge/files/iso/elementary/README.md
@@ -19,7 +19,7 @@ penguins-eggs
 
 All ISOs include eggs, you can udate it with: ```sudo eggs update```.
 
-# Manjaro Linux
+# Elementary 
 
 [Elementary]https://elementary.io/) The thoughtful, capable, and ethical replacement for Windows and macOS.
 
@@ -30,7 +30,7 @@ All ISOs include eggs, you can udate it with: ```sudo eggs update```.
 * Repository: [penguins-eggs](https://github.com/pieroproietti/penguins-eggs)
 * Blog: [penguins-eggs](https://penguins-eggs.net)
 
-* You can find more informations on this Linux distro at: [Elementary]https://elementary.io/).
+* You can find more informations on this Linux distro at: [Elementary](https://elementary.io/).
 
 
 Disclaim

--- a/sourceforge/files/iso/elementary/README.md
+++ b/sourceforge/files/iso/elementary/README.md
@@ -1,0 +1,38 @@
+penguins-eggs
+=============
+
+## Penguin&#39;s eggs are generated and new birds are ready to fly...
+[![sources](https://img.shields.io/badge/github-sources-blue)](https://github.com/pieroproietti/penguins-eggs)
+[![blog](https://img.shields.io/badge/blog-penguin's%20eggs-blue)](https://penguins-eggs.net)
+[![sources-documentation](https://img.shields.io/badge/sources-documentation-blue)](https://penguins-eggs.net/sources-documentation/index.html)
+[![guide](https://img.shields.io/badge/guide-penguin's%20eggs-blue)](https://penguins-eggs.net/book/)
+[![npm version](https://img.shields.io/npm/v/penguins-eggs.svg)](https://npmjs.org/package/penguins-eggs)
+[![deb](https://img.shields.io/badge/deb-packages-orange)](https://sourceforge.net/projects/penguins-eggs/files/packages-deb)
+[![iso](https://img.shields.io/badge/iso-images-orange)](https://sourceforge.net/projects/penguins-eggs/files/iso)
+
+
+# Penguin's eggs remastered ISOs
+
+# user/password
+* ```live/evolution```
+* ```root/evolution```
+
+All ISOs include eggs, you can udate it with: ```sudo eggs update```.
+
+# Manjaro Linux
+
+[Elementary]https://elementary.io/) The thoughtful, capable, and ethical replacement for Windows and macOS.
+
+* **egg-of-elementary-jolnir-pantheon** - remastered version from lementaryos-6.1-stable.20211218-rc.iso 
+
+## More informations:
+
+* Repository: [penguins-eggs](https://github.com/pieroproietti/penguins-eggs)
+* Blog: [penguins-eggs](https://penguins-eggs.net)
+
+* You can find more informations on this Linux distro at: [Elementary]https://elementary.io/).
+
+
+Disclaim
+
+__Please note what this project is in no way connected to the original distro in any official way, it’s just my personal experiment.__

--- a/src/classes/distro.ts
+++ b/src/classes/distro.ts
@@ -5,7 +5,7 @@
  * author: Piero Proietti
  * mail: piero.proietti@gmail.com
  */
-
+ 
 /**
  * Debian 8 (jessie)
  * Debian 9 (stretch)
@@ -280,6 +280,14 @@ class Distro implements IDistro {
 
         break
       }
+
+      case `jolnir`: {
+        // Elementary
+        this.distroLike = 'Ubuntu'
+        this.versionLike = 'focal'
+
+        break
+      } 
 
       case 'roma': {
         // UfficioZero roma

--- a/src/classes/xdg.ts
+++ b/src/classes/xdg.ts
@@ -93,7 +93,14 @@ export default class Xdg {
 
       // lightdm
       if (Pacman.packageIsInstalled('lightdm')) {
-        shx.sed('-i', `autologin-user=${olduser}`, `autologin-user=${newuser}`, `${chroot}/etc/lightdm/lightdm.conf`)
+        if (fs.existsSync(`${chroot}/etc/lightdm/lightdm.conf`)){
+          shx.sed('-i', `autologin-user=${olduser}`, `autologin-user=${newuser}`, `${chroot}/etc/lightdm/lightdm.conf`)
+        } else {
+          const autologin= `${chroot}/etc/lightdm/lightdm.conf`
+          const content = `[Seat:*]\nautologin-user=${newuser}`
+          fs.writeFileSync(autologin, content, 'utf-8')
+        }
+
       }
 
       // sddm


### PR DESCRIPTION
Just little changes to adapt eggs to ElementaryOS, mostly inserted Elementary in distro.ts, changed the way bash-completion is installed (now we try both this path: /etc/bash-completion.d and /usr/share/bash-completion/Completions where this distro want bash-completion scripts) , and a little bugfix for lightdm.conf, don't fail if don't find it, but build a minimun lightdm.conf)
