### PR TITLE
Excludes

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,13 +572,13 @@ Restore users, server and datas from luks-eggs-backup
 
 ```
 USAGE
-  $ eggs restore [-c] [-k] [-h] [-v]
+  $ eggs restore [-k] [-f <value>] [-h] [-v]
 
 FLAGS
-  -c, --calamares  calamares
-  -h, --help       Show CLI help.
-  -k, --krill      krill
-  -v, --verbose    verbose
+  -f, --file=<value>  file with LUKS volume encrypted
+  -h, --help          Show CLI help.
+  -k, --krill         krill
+  -v, --verbose       verbose
 
 DESCRIPTION
   Restore users, server and datas from luks-eggs-backup

--- a/README.md
+++ b/README.md
@@ -573,14 +573,13 @@ Restore users, server and datas from luks-eggs-backup
 
 ```
 USAGE
-  $ eggs syncfrom [-k] [-r <value>] [-f <value>] [-h] [-v]
+  $ eggs syncfrom [-f <value>] [-r <value>] [-h] [-v]
 
 FLAGS
-  -f, --file=<value>  file with LUKS volume encrypted
-  -h, --help          Show CLI help.
-  -k, --krill         krill
-  -r, --root=<value>  root mount of the installed system
-  -v, --verbose       verbose
+  -f, --file=<value>     file with LUKS volume encrypted
+  -h, --help             Show CLI help.
+  -r, --rootdir=<value>  rootdir of the installed system, when used from live
+  -v, --verbose          verbose
 
 DESCRIPTION
   Restore users, server and datas from luks-eggs-backup

--- a/README.md
+++ b/README.md
@@ -584,6 +584,9 @@ FLAGS
 DESCRIPTION
   Restore users, server and datas from luks-eggs-backup
 
+ALIASES
+  $ eggs restore
+
 EXAMPLES
   $ sudo eggs restore
 ```
@@ -606,6 +609,9 @@ FLAGS
 
 DESCRIPTION
   Backup users, server and datas to luks-eggs-backup
+
+ALIASES
+  $ eggs backup
 
 EXAMPLES
   $ sudo eggs restore

--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ USAGE
 * [`eggs mom`](#eggs-mom)
 * [`eggs produce`](#eggs-produce)
 * [`eggs remove`](#eggs-remove)
-* [`eggs restore`](#eggs-restore)
+* [`eggs syncfrom`](#eggs-syncfrom)
+* [`eggs syncto`](#eggs-syncto)
 * [`eggs tools clean`](#eggs-tools-clean)
 * [`eggs tools locales`](#eggs-tools-locales)
 * [`eggs tools skel`](#eggs-tools-skel)
@@ -566,18 +567,19 @@ EXAMPLES
 
 _See code: [src/commands/remove.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.15/src/commands/remove.ts)_
 
-## `eggs restore`
+## `eggs syncfrom`
 
 Restore users, server and datas from luks-eggs-backup
 
 ```
 USAGE
-  $ eggs restore [-k] [-f <value>] [-h] [-v]
+  $ eggs syncfrom [-k] [-r <value>] [-f <value>] [-h] [-v]
 
 FLAGS
   -f, --file=<value>  file with LUKS volume encrypted
   -h, --help          Show CLI help.
   -k, --krill         krill
+  -r, --root=<value>  root mount of the installed system
   -v, --verbose       verbose
 
 DESCRIPTION
@@ -587,7 +589,30 @@ EXAMPLES
   $ sudo eggs restore
 ```
 
-_See code: [src/commands/restore.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.15/src/commands/restore.ts)_
+_See code: [src/commands/syncfrom.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.15/src/commands/syncfrom.ts)_
+
+## `eggs syncto`
+
+Backup users, server and datas to luks-eggs-backup
+
+```
+USAGE
+  $ eggs syncto [-k] [-f <value>] [-h] [-v]
+
+FLAGS
+  -f, --file=<value>  file LUKS volume encrypted
+  -h, --help          Show CLI help.
+  -k, --krill         krill
+  -v, --verbose       verbose
+
+DESCRIPTION
+  Backup users, server and datas to luks-eggs-backup
+
+EXAMPLES
+  $ sudo eggs restore
+```
+
+_See code: [src/commands/syncto.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.15/src/commands/syncto.ts)_
 
 ## `eggs tools clean`
 

--- a/scripts/_eggs
+++ b/scripts/_eggs
@@ -22,15 +22,17 @@ _eggs () {
 "mom:ask for mommy - gui helper"
 "produce:the system produce an egg: iso image of your system"
 "remove:remove eggs and others stuff"
+"syncfrom:Restore users, server and datas from luks-eggs-backup"
+"syncto:Backup users, server and datas to luks-eggs-backup"
 "tools\:clean:clean system log, apt, etc"
 "tools\:locales:install/clean locales"
 "tools\:skel:update skel from home configuration"
 "tools\:stat:get statistics from sourceforge"
 "tools\:yolk:configure eggs to install without internet"
 "update:update the penguin's eggs tool"
-"autocomplete:display autocomplete installation instructions"
 "help:Display help for <%= config.bin %>."
 "version:"
+"autocomplete:display autocomplete installation instructions"
   )
 
   _set_flags () {
@@ -166,6 +168,24 @@ remove)
   )
 ;;
 
+syncfrom)
+  _command_flags=(
+    "--krill[krill]"
+"--file=-[file with LUKS volume encrypted]:"
+"--help[Show CLI help.]"
+"--verbose[verbose]"
+  )
+;;
+
+syncto)
+  _command_flags=(
+    "--krill[krill]"
+"--file=-[file LUKS volume encrypted]:"
+"--help[Show CLI help.]"
+"--verbose[verbose]"
+  )
+;;
+
 tools:clean)
   _command_flags=(
     "--help[Show CLI help.]"
@@ -213,12 +233,6 @@ update)
   )
 ;;
 
-autocomplete)
-  _command_flags=(
-    "--refresh-cache[Refresh cache (ignores displaying instructions)]"
-  )
-;;
-
 help)
   _command_flags=(
     "--nested-commands[Include all nested commands in the output.]"
@@ -228,6 +242,12 @@ help)
 version)
   _command_flags=(
     
+  )
+;;
+
+autocomplete)
+  _command_flags=(
+    "--refresh-cache[Refresh cache (ignores displaying instructions)]"
   )
 ;;
 

--- a/scripts/eggs.bash
+++ b/scripts/eggs.bash
@@ -26,15 +26,17 @@ kill --help --verbose
 mom --help
 produce --prefix --basename --backup --fast --normal --max --verbose --yolk --script --help --theme --addons --release
 remove --purge --autoremove --help --verbose
+syncfrom --krill --file --help --verbose
+syncto --krill --file --help --verbose
 tools:clean --help --verbose
 tools:locales --help --reinstall --verbose
 tools:skel --help --user --verbose
 tools:stat --help --month --year
 tools:yolk --help --verbose
 update --help --apt --basket --verbose
-autocomplete --refresh-cache
 help --nested-commands
 version 
+autocomplete --refresh-cache
 "
 
   function __trim_colon_commands()

--- a/src/classes/krill_install.tsx
+++ b/src/classes/krill_install.tsx
@@ -232,12 +232,12 @@ export default class Hatching {
             percent = 0.37
             try {
                redraw(<Install message={message} percent={percent} spinner={true} />)
-               await exec('eggs syncfrom -f /tmp/calamares-krill-root/')
+               await exec('eggs syncfrom --rootdir /tmp/calamares-krill-root/')
             } catch (error) {
                message += JSON.stringify(error)
                redraw(<Install message={message} percent={percent} />)
             }
-            await checkIt(message)
+            // await checkIt(message)
          }
 
          // sources-yolk

--- a/src/classes/krill_install.tsx
+++ b/src/classes/krill_install.tsx
@@ -232,12 +232,12 @@ export default class Hatching {
             percent = 0.37
             try {
                redraw(<Install message={message} percent={percent} spinner={true} />)
-               await exec('eggs restore --krill --verbose')
+               await exec('eggs syncfrom -f /tmp/calamares-krill-root/')
             } catch (error) {
                message += JSON.stringify(error)
                redraw(<Install message={message} percent={percent} />)
             }
-            //await checkIt(message)
+            await checkIt(message)
          }
 
          // sources-yolk

--- a/src/classes/users.ts
+++ b/src/classes/users.ts
@@ -56,7 +56,7 @@ export default class Users {
             { path: 'mnt', saveIt: false },
             { path: 'opt', saveIt: true },
             { path: 'proc', saveIt: false },
-            { path: 'root', saveIt: true },
+            { path: 'root', saveIt: false },
             { path: 'run', saveIt: false },
             { path: 'sbin', saveIt: false },
             { path: 'sys', saveIt: false },

--- a/src/commands/restore.ts
+++ b/src/commands/restore.ts
@@ -7,6 +7,7 @@
 import { Command, Flags } from '@oclif/core'
 
 import fs = require('fs')
+import path = require('path')
 import Utils from '../classes/utils'
 import { exec } from '../lib/utils'
 
@@ -17,13 +18,13 @@ export default class Restore extends Command {
   luksName = 'luks-eggs-backup'
   luksFile = `/run/live/medium/live/${this.luksName}`
   luksDevice = `/dev/mapper/${this.luksName}`
-  luksMountpoint = '/mnt'
+  luksMountpoint = '/tmp/eggs-backup'
 
   static description = 'Restore users, server and datas from luks-eggs-backup'
 
   static flags = {
-    calamares: Flags.boolean({ char: 'c', description: 'calamares' }),
     krill: Flags.boolean({ char: 'k', description: 'krill' }),
+    file: Flags.string({ char: 'f', description: "file with LUKS volume encrypted" }),
     help: Flags.help({ char: 'h' }),
     verbose: Flags.boolean({ char: 'v', description: 'verbose' })
   }
@@ -31,27 +32,74 @@ export default class Restore extends Command {
   static examples = ['$ sudo eggs restore']
 
   async run(): Promise<void> {
-    //Utils.titles(this.id + ' ' + this.argv)
 
     const { flags } = await this.parse(Restore)
     let verbose = false
     if (flags.verbose) {
       verbose = true
     }
+
+    let fileVolume = ''
+    if (flags.file) {
+      fileVolume = flags.file
+    }
+
     const echo = Utils.setEcho(verbose)
     if (Utils.isRoot(this.id)) {
-      if (Utils.isLive()) {
-        if (!flags.calamares || !flags.krill) {
-          if (fs.existsSync(this.luksFile)) {
+      if (flags.file && flags.krill) {
+        Utils.warning(`You must use eggs restore or with`)
+      }
+
+      if (!Utils.isLive()) {
+        /**
+         * restore con file
+         */
+        if (fileVolume !== '') {
+          if (fs.existsSync(fileVolume)) {
+            this.luksName = path.basename(fileVolume)
+            this.luksFile = fileVolume
+            this.luksDevice = `/dev/mapper/${this.luksName}`
+            this.luksMountpoint = '/tmp/eggs-backup'
             await this.restorePrivateData(verbose)
           } else {
             Utils.warning(`Can't find ${this.luksFile}`)
           }
         } else {
-          Utils.warning(`eggs restore it's an internal command used from installers only`)
+          /**
+           * restore con krill su LIVE
+           */
+          if (flags.krill) {
+            this.luksName = 'luks-eggs-backup'
+            this.luksFile = `/run/live/medium/live/${this.luksName}`
+            this.luksDevice = `/dev/mapper/${this.luksName}`
+            this.luksMountpoint = '/tmp/eggs-backup'
+            if (fs.existsSync(this.luksFile)) {
+              await this.restorePrivateData(verbose)
+              if (await Utils.customConfirm(`Your installed system was updated! Press a key to reboot`)) {
+                await exec('reboot')
+              }
+              Utils.warning(`Can't find ${this.luksFile}, sure You used eggs backup to produce this LIVE?`)
+            }
+          } else {
+            Utils.warning(`You can use eggs restore --krill only from LIVE system`)
+          }
         }
       } else {
-        Utils.warning('You cannot use: eggs restore on installed systems')
+        /**
+         * SIAMO SU IN SISTEMA INSTALLATO
+         */
+        if (fs.existsSync(fileVolume)) {
+          this.luksName = path.basename(fileVolume)
+          this.luksFile = fileVolume
+          this.luksDevice = `/dev/mapper/${this.luksName}`
+          this.luksMountpoint = '/tmp/eggs-backup'
+          await this.restorePrivateData(verbose)
+          if (await Utils.customConfirm(`Your system was updated! Press a key to reboot`)) {
+            await exec('reboot')
+          }
+        } else {
+          Utils.warning(`Can't find ${this.luksFile}`)
+        }
       }
     }
   }
@@ -61,26 +109,39 @@ export default class Restore extends Command {
    * @param verbose 
    */
   private async restorePrivateData(verbose = false) {
+
+    if (!fs.existsSync(this.luksMountpoint)) {
+      await exec(`mkdir ${this.luksMountpoint}`)
+    }
+
     const echo = Utils.setEcho(verbose)
     const echoYes = Utils.setEcho(verbose)
 
     Utils.warning(`Opening volume ${this.luksName}, you MUST user the same passphrase you choose during the backup`)
     let crytoSetup = await exec(`cryptsetup luksOpen --type luks2 ${this.luksFile} ${this.luksName}`, echoYes)
 
-
     Utils.warning(`mount ${this.luksDevice} ${this.luksMountpoint}`)
     await exec(`mount ${this.luksDevice} ${this.luksMountpoint}`, echoYes)
 
-    Utils.warning('Removing live user on the destination system')
-    await exec(`rm -rf /tmp/calamares-krill-root/home/*`, echo)
+    /**
+     * ONLY IN INSTALLING SYSTEMS
+     * rm home, subst /etc/passwd, /etc/shadow, /etc/groups
+     */
+    if (Utils.isLive()) {
+      Utils.warning('Removing live user on the destination system')
+      await exec(`rm -rf /tmp/calamares-krill-root/home/*`, echo)
 
-    Utils.warning('Restoring backup data on the installing system')
-    await exec(`rsync -a ${this.luksMountpoint}/ROOT/ /tmp/calamares-krill-root/`, echo)
+      Utils.warning('Restoring accounts on the installing system')
+      await exec(`cp ${this.luksMountpoint}/etc/passwd /tmp/calamares-krill-root/etc/`, echo)
+      await exec(`cp ${this.luksMountpoint}/etc/shadow /tmp/calamares-krill-root/etc/`, echo)
+      await exec(`cp ${this.luksMountpoint}/etc/group /tmp/calamares-krill-root/etc/`, echo)
+      Utils.warning('Restoring backup data on the installing system')
+      await exec(`rsync -a ${this.luksMountpoint}/ROOT/ /tmp/calamares-krill-root/`, echo)
+    } else {
+      Utils.warning('Restoring backup data on the installing system')
+      await exec(`rsync -a ${this.luksMountpoint}/ROOT/ /`, echo)
+    }
 
-    Utils.warning('Restoring accounts on the installing system')
-    await exec(`cp ${this.luksMountpoint}/etc/passwd /tmp/calamares-krill-root/etc/`, echo)
-    await exec(`cp ${this.luksMountpoint}/etc/shadow /tmp/calamares-krill-root/etc/`, echo)
-    await exec(`cp ${this.luksMountpoint}/etc/group /tmp/calamares-krill-root/etc/`, echo)
 
     Utils.warning(`unmount volume ${this.luksName}`)
     await exec(`umount ${this.luksMountpoint}`, echo)

--- a/src/commands/syncfrom.ts
+++ b/src/commands/syncfrom.ts
@@ -28,6 +28,8 @@ export default class Syncfrom extends Command {
     verbose: Flags.boolean({ char: 'v', description: 'verbose' })
   }
 
+  static aliases = ['restore']
+
   static examples = ['$ sudo eggs restore']
 
   async run(): Promise<void> {
@@ -58,16 +60,11 @@ export default class Syncfrom extends Command {
     if (Utils.isRoot(this.id)) {
       if (fileVolume === '') {
         fileVolume = '/run/live/medium/live/luks-eggs-backup'
-        Utils.warning(`You didn't give any file, I will use ${fileVolume}`)
       }
 
       if (!Utils.isLive()) {
         /**
          * WORKING FROM INSTALLED
-         */
-
-        /**
-         * restore con file on INSTALLED system
          */
         if (fs.existsSync(fileVolume)) {
           this.luksName = path.basename(fileVolume)
@@ -76,10 +73,8 @@ export default class Syncfrom extends Command {
           this.luksMountpoint = '/tmp/eggs-backup'
 
           await this.restorePrivateData(verbose)
-          if (this.rootDir === '/') {
-            if (await Utils.customConfirm(`Your system was updated! Press a key to reboot`)) {
-              await exec('reboot')
-            }
+          if (await Utils.customConfirm(`Your system was updated! Press a key to reboot`)) {
+            await exec('reboot')
           }
         } else {
           Utils.warning(`Can't find ${this.luksFile}`)
@@ -88,20 +83,11 @@ export default class Syncfrom extends Command {
         /**
          * WORKING FROM LIVE
          */
-
-        /**
-         * restore con file from LIVE system
-         */
         this.luksName = path.basename(fileVolume)
         this.luksFile = fileVolume
         this.luksDevice = `/dev/mapper/${this.luksName}`
         this.luksMountpoint = '/tmp/eggs-backup'
         await this.restorePrivateData(verbose)
-        if (await Utils.customConfirm(`Your INSTALLED system was updated! Press a key to reboot`)) {
-          await exec('reboot')
-        } else {
-          Utils.warning(`Check yours options...}`)
-        }
       }
     }
   }

--- a/src/commands/syncfrom.ts
+++ b/src/commands/syncfrom.ts
@@ -12,7 +12,7 @@ import Utils from '../classes/utils'
 import { exec } from '../lib/utils'
 
 
-export default class Restore extends Command {
+export default class Syncfrom extends Command {
   config_file = '/etc/penguins-eggs.d/eggs.yaml' as string
 
   luksName = 'luks-eggs-backup'
@@ -33,7 +33,7 @@ export default class Restore extends Command {
 
   async run(): Promise<void> {
 
-    const { flags } = await this.parse(Restore)
+    const { flags } = await this.parse(Syncfrom)
     let verbose = false
     if (flags.verbose) {
       verbose = true

--- a/src/commands/syncfrom.ts
+++ b/src/commands/syncfrom.ts
@@ -76,8 +76,10 @@ export default class Syncfrom extends Command {
           this.luksMountpoint = '/tmp/eggs-backup'
 
           await this.restorePrivateData(verbose)
-          if (await Utils.customConfirm(`Your system was updated! Press a key to reboot`)) {
-            await exec('reboot')
+          if (this.rootDir === '/') {
+            if (await Utils.customConfirm(`Your system was updated! Press a key to reboot`)) {
+              await exec('reboot')
+            }
           }
         } else {
           Utils.warning(`Can't find ${this.luksFile}`)

--- a/src/commands/syncto.ts
+++ b/src/commands/syncto.ts
@@ -1,0 +1,193 @@
+/**
+ * penguins-eggs-v9
+ * author: Piero Proietti
+ * email: piero.proietti@gmail.com
+ * license: MIT
+ */
+import { Command, Flags } from '@oclif/core'
+
+import fs = require('fs')
+import path = require('path')
+import Utils from '../classes/utils'
+import { exec } from '../lib/utils'
+// backup
+import { access } from 'fs/promises'
+import { constants } from 'fs'
+import Users from '../classes/users'
+
+export default class Syncto extends Command {
+    luksName = 'luks-eggs-backup'
+    luksFile = `/run/live/medium/live/${this.luksName}`
+    luksDevice = `/dev/mapper/${this.luksName}`
+    luksMountpoint = '/tmp/eggs-backup'
+
+    static description = 'Backup users, server and datas to luks-eggs-backup'
+
+    static flags = {
+        krill: Flags.boolean({ char: 'k', description: 'krill' }),
+        file: Flags.string({ char: 'f', description: "file LUKS volume encrypted" }),
+        help: Flags.help({ char: 'h' }),
+        verbose: Flags.boolean({ char: 'v', description: 'verbose' })
+    }
+
+    static examples = ['$ sudo eggs restore']
+
+    /**
+     * 
+     */
+    async run(): Promise<void> {
+
+        const { flags } = await this.parse(Syncto)
+        let verbose = false
+        if (flags.verbose) {
+            verbose = true
+        }
+
+        let fileVolume = ''
+        if (flags.file) {
+            fileVolume = flags.file
+        }
+
+        const echo = Utils.setEcho(verbose)
+        if (Utils.isRoot(this.id)) {
+            /**
+             * restore con file
+             */
+            if (fileVolume === '') {
+                fileVolume = '/tmp/luks-eggs-backup'
+            }
+
+            this.luksName = path.basename(fileVolume)
+            this.luksFile = fileVolume
+            this.luksDevice = `/dev/mapper/${this.luksName}`
+            this.luksMountpoint = '/tmp/eggs-backup'
+            if (!fs.existsSync(fileVolume)) {
+                await this.luksCreate(verbose)
+            } else {
+                Utils.warning(`LUKS volume: ${this.luksFile} exist, don't need create`)
+            }
+            if (fs.existsSync(fileVolume)) {
+                await this.luksOpen(verbose)
+                await this.luksClose(verbose)
+            }
+        }
+    }
+
+    /**
+    * usersFill
+    */
+    async usersFill(): Promise<Users[]> {
+        const usersArray = []
+        await access('/etc/passwd', constants.R_OK | constants.W_OK);
+        const passwd = fs.readFileSync('/etc/passwd', 'utf-8').split('\n')
+        for (let i = 0; i < passwd.length; i++) {
+            var line = passwd[i].split(':')
+            const users = new Users(line[0], line[1], line[2], line[3], line[4], line[5], line[6])
+            await users.getValues()
+            if (users.password !== undefined) {
+                usersArray.push(users)
+            }
+        }
+        return usersArray
+    }
+
+
+    /**
+     * 
+     */
+    async luksCreate(verbose = false) {
+        const echo = Utils.setEcho(verbose)
+        const echoYes = Utils.setEcho(true)
+
+        Utils.warning(`Creating LUKS Volume on ${this.luksFile}`)
+
+        let totalSize = 0
+        console.log(`I will extimate volume size from your private data:`)
+        const users = await this.usersFill()
+        for (let i = 0; i < users.length; i++) {
+            if (users[i].login !== 'root') {
+                if (users[i].saveIt) {
+                    console.log(`user: ${users[i].login} \thome: ${users[i].home.padEnd(16)} \tsize: ${Utils.formatBytes(users[i].size)} \tBytes: ${users[i].size} `)
+                    totalSize += users[i].size
+                }
+            }
+        }
+        console.log(`Total\t\t\t\t\tSize: ${Utils.formatBytes(totalSize)} \tBytes: ${totalSize}`)
+
+        /**
+         * after we get size, we can start building luks-volume
+         */
+        const binaryHeaderSize = 4194304
+        let volumeSize = totalSize * 1.2 + binaryHeaderSize
+
+        // Deciding blockSize and blocks
+        let blockSize = 1024
+        let blocks = Math.ceil(volumeSize / blockSize)
+
+        // We need a minimum size of 32 MB
+        let minimunSize = 134217728 // 128 * 1024 *1024
+        if (totalSize < minimunSize) {
+        }
+        if (blocks * blockSize < minimunSize) {
+            blocks = Math.ceil(minimunSize / blockSize)
+        }
+
+        Utils.warning(`Creating an encrypted file ${this.luksFile} blocks=${blocks}, block size: ${blockSize}, size: ${Utils.formatBytes(blocks * blockSize)}`)
+        await exec(`dd if=/dev/zero of=${this.luksFile} bs=${blockSize} count=${blocks}`, echo)
+
+        // find first unused device
+        let findFirstUnusedDevice = await exec(`losetup -f`, { echo: verbose, ignore: false, capture: true })
+        let firstUnusedDevice = ''
+        if (findFirstUnusedDevice.code !== 0) {
+            Utils.warning(`Error: ${findFirstUnusedDevice.code} ${findFirstUnusedDevice.data}`)
+            process.exit(1)
+        } else {
+            firstUnusedDevice = findFirstUnusedDevice.data.trim()
+        }
+        await exec(`losetup ${firstUnusedDevice} ${this.luksFile}`, echo)
+
+        Utils.warning('Enter a large string of random text below to setup the pre-encryption')
+        await exec(`cryptsetup -y -v --type luks2 luksFormat  ${this.luksFile}`, echoYes)
+
+        Utils.warning(`Enter the desired passphrase for the encrypted ${this.luksName} below`)
+        let crytoSetup = await exec(`cryptsetup luksOpen --type luks2 ${this.luksFile} ${this.luksName}`, echoYes)
+        if (crytoSetup.code !== 0) {
+            Utils.warning(`Error: ${crytoSetup.code} ${crytoSetup.data}`)
+            process.exit(1)
+        }
+
+        Utils.warning(`Formatting ${this.luksDevice} to ext2`)
+        let formatting = await exec(`sudo mkfs.ext2 ${this.luksDevice}`, echo)
+        if (formatting.code !== 0) {
+            Utils.warning(`Error: ${formatting.code} ${formatting.data}`)
+            process.exit(1)
+        }
+        this.luksClose()
+    }
+
+
+    /**
+     * 
+     */
+    async luksOpen(verbose = false) {
+        const echo = Utils.setEcho(verbose)
+
+        Utils.warning(`LUKS open volume: ${this.luksName}`)
+    }
+
+
+    /**
+    * 
+    */
+    async luksClose(verbose = false) {
+        const echo = Utils.setEcho(verbose)
+
+        Utils.warning(`LUKS close volume: ${this.luksName}`)
+        await exec(`cryptsetup luksClose ${this.luksName}`, echo)
+    }
+
+}
+
+
+
+

--- a/src/commands/syncto.ts
+++ b/src/commands/syncto.ts
@@ -32,6 +32,8 @@ export default class Syncto extends Command {
         verbose: Flags.boolean({ char: 'v', description: 'verbose' })
     }
 
+    static aliases = ['backup']
+
     static examples = ['$ sudo eggs restore']
 
     /**


### PR DESCRIPTION
Completed backup! It's possbile:
* produce: users data will be NOT copied, but servers data will be copied uncrypted on the ISO
* produce --backup: users and servers data will be excluded from the ISO, but copied in a LUKS volume inside
* (backup) syncto -f /path/to/luck-eggs-backup produce just the LUKS volume 
* (restore)  syncfrom --f /path/to/luck-eggs-backup -r /path/to/rootdir: restore from the LUKS volume
* krill will automatically restore your luks-eggs-backup
* if you install with calamares, you can restore with: syncfrom --f /path/to/luck-eggs-backup -r /path/to/rootdir