### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ $ npm install -g penguins-eggs
 $ eggs COMMAND
 running command...
 $ eggs (--version|-v)
-penguins-eggs/9.0.49 linux-x64 node-v16.14.2
+penguins-eggs/9.1.0 linux-x64 node-v16.14.2
 $ eggs --help [COMMAND]
 USAGE
   $ eggs COMMAND
@@ -206,7 +206,7 @@ ALIASES
   $ eggs adjust
 ```
 
-_See code: [src/commands/adapt.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.49/src/commands/adapt.ts)_
+_See code: [src/commands/adapt.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.1.0/src/commands/adapt.ts)_
 
 ## `eggs adjust`
 
@@ -246,7 +246,7 @@ EXAMPLES
   $ sudo eggs analyze
 ```
 
-_See code: [src/commands/analyze.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.49/src/commands/analyze.ts)_
+_See code: [src/commands/analyze.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.1.0/src/commands/analyze.ts)_
 
 ## `eggs autocomplete [SHELL]`
 
@@ -316,7 +316,7 @@ DESCRIPTION
   bro: waydroid helper
 ```
 
-_See code: [src/commands/bro.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.49/src/commands/bro.ts)_
+_See code: [src/commands/bro.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.1.0/src/commands/bro.ts)_
 
 ## `eggs calamares`
 
@@ -345,7 +345,7 @@ EXAMPLES
   install calamares and create it's configuration's files
 ```
 
-_See code: [src/commands/calamares.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.49/src/commands/calamares.ts)_
+_See code: [src/commands/calamares.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.1.0/src/commands/calamares.ts)_
 
 ## `eggs clean`
 
@@ -391,7 +391,7 @@ EXAMPLES
   Configure and install prerequisites deb packages to run it
 ```
 
-_See code: [src/commands/config.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.49/src/commands/config.ts)_
+_See code: [src/commands/config.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.1.0/src/commands/config.ts)_
 
 ## `eggs dad`
 
@@ -411,7 +411,7 @@ DESCRIPTION
   ask help from daddy - configuration helper
 ```
 
-_See code: [src/commands/dad.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.49/src/commands/dad.ts)_
+_See code: [src/commands/dad.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.1.0/src/commands/dad.ts)_
 
 ## `eggs export deb`
 
@@ -529,7 +529,7 @@ DESCRIPTION
   re-thinking for a different approach to CLI
 ```
 
-_See code: [src/commands/info.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.49/src/commands/info.ts)_
+_See code: [src/commands/info.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.1.0/src/commands/info.ts)_
 
 ## `eggs install`
 
@@ -558,7 +558,7 @@ EXAMPLES
   Install the system using GUI or CLI installer
 ```
 
-_See code: [src/commands/install.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.49/src/commands/install.ts)_
+_See code: [src/commands/install.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.1.0/src/commands/install.ts)_
 
 ## `eggs kill`
 
@@ -580,7 +580,7 @@ EXAMPLES
   kill the eggs/free the nest
 ```
 
-_See code: [src/commands/kill.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.49/src/commands/kill.ts)_
+_See code: [src/commands/kill.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.1.0/src/commands/kill.ts)_
 
 ## `eggs krill`
 
@@ -687,7 +687,7 @@ DESCRIPTION
   ask for mommy - gui helper
 ```
 
-_See code: [src/commands/mom.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.49/src/commands/mom.ts)_
+_See code: [src/commands/mom.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.1.0/src/commands/mom.ts)_
 
 ## `eggs prerequisites`
 
@@ -777,7 +777,7 @@ EXAMPLES
   in /home/eggs/ovarium and you can customize all you need
 ```
 
-_See code: [src/commands/produce.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.49/src/commands/produce.ts)_
+_See code: [src/commands/produce.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.1.0/src/commands/produce.ts)_
 
 ## `eggs remove`
 
@@ -807,7 +807,7 @@ EXAMPLES
   remove eggs, eggs configurations, packages dependencies
 ```
 
-_See code: [src/commands/remove.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.49/src/commands/remove.ts)_
+_See code: [src/commands/remove.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.1.0/src/commands/remove.ts)_
 
 ## `eggs restore`
 
@@ -966,7 +966,7 @@ EXAMPLES
   $ sudo eggs restore
 ```
 
-_See code: [src/commands/syncfrom.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.49/src/commands/syncfrom.ts)_
+_See code: [src/commands/syncfrom.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.1.0/src/commands/syncfrom.ts)_
 
 ## `eggs syncto`
 
@@ -992,7 +992,7 @@ EXAMPLES
   $ sudo eggs syncto
 ```
 
-_See code: [src/commands/syncto.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.49/src/commands/syncto.ts)_
+_See code: [src/commands/syncto.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.1.0/src/commands/syncto.ts)_
 
 ## `eggs tools clean`
 
@@ -1115,7 +1115,7 @@ EXAMPLES
   update/upgrade the penguin's eggs tool
 ```
 
-_See code: [src/commands/update.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.0.49/src/commands/update.ts)_
+_See code: [src/commands/update.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.1.0/src/commands/update.ts)_
 
 ## `eggs version`
 

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,16 @@ You can follow the project also consulting the [commit history](https://github.c
 ## Changelog
 Versions are listed on reverse order, the first is the last one. Old versions are moved to [oldest](https://sourceforge.net/projects/penguins-eggs/files/packages-deb/oldest/). 
 
+### eggs-9.1.0-1
+
+A breacking news!
+
+* wardrobe: after a bit of consolidation, I moved the suddivision of firmwares from the code to the wardrobe organization. ```firmwares``` now is a accessory with same own internal accessories. 
+* accessories: now accessories can be external and internal. Internal accessories live inside the costume, for example  inside firmwares live codecs, network-cable and so on. Internal accessories have suffix: ```./```: ```./codecs```, ```./network-cable```, etc.
+* If you open ```wardrobe.d/accessories/firmwares```, you can find inside: codecs, network-cable, printers, video-nvidia, network-wifi, video-amd and ou are free to add others. 
+
+This result in a great semplification of code and a improved organization. Just adding others firmware categories inside firmwares - such graphics-tables - add an index.yml with the packages you needs; note: if your packages need a specific repo, you can add it too. Add your new accessory on index.yml of firmares and eggs will load it, add the request repos then install yours packages.
+
 ### eggs-9.0.49-1
 wardrobe: introduced accessories for costumes, you can wear a costume and choose the accessories to wear with. 
 * base, 
@@ -28,7 +38,7 @@ Costume hen, now specific just xfce4 configuration and take all the capabilities
 
 ### eggs-9.0.48-1
 * wardrobe: added firmwares: [drivers_wifi, codecs, drivers_various, drivers_video_nvidia, drivers_video_amd, drivers_graphics_tablet, drivers_printer, drivers_network];
-* wardrobe: having a dress is pretty useless if it's not ironed, let's introduce **wardrobe ironing** to sort all sortables inside
+* wardrobe: having a dress is pretty useless if it's not ironed, let's introduce **wardrobe ironing** to sort all sortables
 
 ### eggs-9.0.47-1
 * krill: model, layout, variant and option are selected from ```/usr/share/X11/xkb/rules/xorg.lst``` to be compatible with not systemd systems

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "penguins-eggs",
-    "version": "9.0.49",
+    "version": "9.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "penguins-eggs",
-            "version": "9.0.49",
+            "version": "9.1.0",
             "license": "MIT",
             "dependencies": {
                 "@oclif/plugin-autocomplete": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "penguins-eggs",
     "description": "Perri's Brewery edition: remaster your system and distribuite it",
-    "version": "9.0.49",
+    "version": "9.1.0",
     "author": "Piero Proietti @pieroproietti",
     "bin": {
         "eggs": "bin/run"

--- a/src/classes/tailor.ts
+++ b/src/classes/tailor.ts
@@ -171,8 +171,6 @@ export default class Tailor {
         }
 
 
-
-
         /**
          * checking dependencies
          */
@@ -199,69 +197,6 @@ export default class Tailor {
             )
         }
 
-        /**
-         * firmwares
-         */
-        if (this.materials.sequence.firmwares !== undefined) {
-
-            /**
-             * codecs
-             */
-            if (this.materials.sequence.firmwares.codecs !== undefined) {
-                await this.helper(this.materials.sequence.firmwares.codecs, 'codecs')
-            }
-
-            /**
-             * drivers_graphics_tablet
-             */
-            if (this.materials.sequence.firmwares.drivers_graphics_tablet !== undefined) {
-                await this.helper(this.materials.sequence.firmwares.drivers_graphics_tablet, "graphics tablet")
-            }
-
-            /**
-             * drivers_network
-             */
-            if (this.materials.sequence.firmwares.drivers_network !== undefined) {
-                await this.helper(this.materials.sequence.firmwares.drivers_network, "network")
-            }
-
-            /**
-             * drivers_various
-             */
-            if (this.materials.sequence.firmwares.drivers_various !== undefined) {
-                await this.helper(this.materials.sequence.firmwares.drivers_various, "various firmwares")
-            }
-
-            /**
-             * drivers_video_amd
-             */
-            if (this.materials.sequence.firmwares.drivers_video_amd !== undefined) {
-                await this.helper(this.materials.sequence.firmwares.drivers_video_amd, "video AMD")
-            }
-
-            /**
-             * drivers_video_nvidia
-             */
-            if (this.materials.sequence.firmwares.drivers_video_nvidia !== undefined) {
-                await this.helper(this.materials.sequence.firmwares.drivers_video_nvidia, "video NVIDIA")
-            }
-
-            /**
-             * drivers_wifi
-             */
-            if (this.materials.sequence.firmwares.drivers_wifi !== undefined) {
-                await this.helper(this.materials.sequence.firmwares.drivers_wifi, "wifi")
-            }
-
-            /**
-             * drivers_printer
-             */
-            if (this.materials.sequence.firmwares.drivers_printer !== undefined) {
-                await this.helper(this.materials.sequence.firmwares.drivers_printer, 'printers')
-            }
-        }
-
-
 
         /**
          * dpkg -i *.deb
@@ -274,7 +209,6 @@ export default class Tailor {
                 await exec(cmd)
             }
         }
-
 
 
         /**
@@ -294,6 +228,24 @@ export default class Tailor {
             }
         }
 
+
+        /**
+         * accessories
+         */
+        if (this.materials.sequence.accessories !== undefined) {
+            if (this.materials.sequence.accessories[0] !== null) {
+                let step = `wearing accessories`
+                for (const elem of this.materials.sequence.accessories) {
+                    if (elem.substring(0, 2) === './') {
+                        const tailor = new Tailor(this.wardrobe, `${this.costume}/${elem.substring(2)}`)
+                        await tailor.prepare(verbose)
+                    } else {
+                        const tailor = new Tailor(this.wardrobe, `./accessories/${elem}`)
+                        await tailor.prepare(verbose)
+                    }
+                }
+            }
+        }
 
 
         /**
@@ -316,21 +268,6 @@ export default class Tailor {
                     cmd = `rsync -avx  ${this.wardrobe}/${this.costume}/dirs/etc/skel/.* /home/${user}/`
                     await exec(cmd, this.echo)
                     await exec(`chown ${user}:${user} /home/${user}/ -R`)
-                }
-            }
-        }
-
-
-
-        /**
-         * accessories
-         */
-        if (this.materials.sequence.accessories !== undefined) {
-            if (this.materials.sequence.accessories[0] !== null) {
-                let step = `wearing accessories`
-                for (const elem of this.materials.sequence.accessories) {
-                    const tailor = new Tailor(this.wardrobe, `./accessories/${elem}`)
-                    await tailor.prepare(verbose)
                 }
             }
         }

--- a/src/commands/wardrobe/ironing.ts
+++ b/src/commands/wardrobe/ironing.ts
@@ -108,41 +108,6 @@ export default class Ironing extends Command {
             }
         }
 
-        if (orig.sequence.firmwares !== undefined) {
-            if (orig.sequence.firmwares.codecs !== undefined) {
-                sorted.sequence.firmwares.codecs = orig.sequence.firmwares.codecs.sort()
-            }
-
-            if (orig.sequence.firmwares.drivers_graphics_tablet !== undefined) {
-                sorted.sequence.firmwares.drivers_graphics_tablet = orig.sequence.firmwares.drivers_graphics_tablet.sort()
-            }
-
-            if (orig.sequence.firmwares.drivers_network !== undefined) {
-                sorted.sequence.firmwares.drivers_network = orig.sequence.firmwares.drivers_network.sort()
-            }
-
-            if (orig.sequence.firmwares.drivers_various !== undefined) {
-                sorted.sequence.firmwares.drivers_various = orig.sequence.firmwares.drivers_various.sort()
-            }
-
-            if (orig.sequence.firmwares.drivers_video_amd !== undefined) {
-                sorted.sequence.firmwares.drivers_video_amd = orig.sequence.firmwares.drivers_video_amd.sort()
-            }
-
-            if (orig.sequence.firmwares.drivers_video_nvidia !== undefined) {
-                sorted.sequence.firmwares.drivers_video_nvidia = orig.sequence.firmwares.drivers_video_nvidia.sort()
-            }
-
-            if (orig.sequence.firmwares.drivers_wifi !== undefined) {
-                sorted.sequence.firmwares.drivers_wifi = orig.sequence.firmwares.drivers_wifi.sort()
-            }
-
-            if (orig.sequence.firmwares.drivers_printer !== undefined) {
-                sorted.sequence.firmwares.drivers_printer = orig.sequence.firmwares.drivers_printer.sort()
-            }
-
-        }
-
         sorted.sequence.debs = orig.sequence.debs
         sorted.sequence.dirs = orig.sequence.dirs
         sorted.sequence.hostname = orig.sequence.hostname

--- a/src/interfaces/i-costume.ts
+++ b/src/interfaces/i-costume.ts
@@ -21,16 +21,6 @@ export interface ICostume {
         dependencies: string []
         packages: string [],
         noInstallRecommends: string [],
-        firmwares: {
-            codecs: string[],
-            drivers_graphics_tablet: string[],
-            drivers_network: string[],
-            drivers_printer: string[],
-            drivers_various: string[],
-            drivers_video_amd: string[],
-            drivers_video_nvidia: string[],
-            drivers_wifi: string[],
-        }
         debs: boolean,
         packagesPip: string [],
         dirs: boolean,

--- a/wardrobe.d/accessories/firmwares/codecs/index.yml
+++ b/wardrobe.d/accessories/firmwares/codecs/index.yml
@@ -1,0 +1,13 @@
+# codecs
+---
+name: codecs
+description: "install codecs"
+author: artisan
+release: 0.0.1
+applyTo: all
+distroId: Debian
+codenameId: bullseye
+releaseId: stable
+sequence:
+  packages:
+    - unace-nonfree

--- a/wardrobe.d/accessories/firmwares/network-cable/index.yml
+++ b/wardrobe.d/accessories/firmwares/network-cable/index.yml
@@ -1,4 +1,4 @@
-# firmwares
+# network drivers - to check
 ---
 name: firmwares
 description: "install firmware"
@@ -9,12 +9,10 @@ distroId: Debian
 codenameId: bullseye
 releaseId: stable
 sequence:
-  accessories:
-  - ./codecs
-  - ./network-cable
-  - ./network-wifi
-  - ./printers
-  - ./video-amd
-  - ./video-nvidia
-
-  
+  packages:
+  - hardinfo
+  - mobile-broadband-provider-info
+  - pppconfig
+  - usb-modeswitch
+  - usb-modeswitch-data
+  - wvdial

--- a/wardrobe.d/accessories/firmwares/network-wifi/index.yml
+++ b/wardrobe.d/accessories/firmwares/network-wifi/index.yml
@@ -1,0 +1,46 @@
+# drivers-wifi
+---
+name: drivers-wifi
+description: "install firmware drivers-wifi"
+author: artisan
+release: 0.0.1
+applyTo: all
+distroId: Debian
+codenameId: bullseye
+releaseId: stable
+sequence:
+  packages:
+  - dahdi-firmware-nonfree
+  - dns323-firmware-tools
+  - firmware-adi
+  - firmware-amd-graphics
+  - firmware-atheros
+  - firmware-b43-installer
+  - firmware-b43legacy-installer
+  - firmware-bnx2
+  - firmware-bnx2x
+  - firmware-brcm80211
+  - firmware-cavium
+  - firmware-intel-sound
+  - firmware-intelwimax
+  - firmware-ipw2x00
+  - firmware-ivtv
+  - firmware-iwlwifi
+  - firmware-libertas
+  - firmware-linux
+  - firmware-linux-free
+  - firmware-linux-nonfree
+  - firmware-myricom
+  - firmware-netronome
+  - firmware-netxen
+  - firmware-qcom-media
+  - firmware-qlogic
+  - firmware-ralink
+  - firmware-realtek
+  - firmware-samsung
+  - firmware-siano
+  - firmware-ti-connectivity
+  - firmware-zd1211
+  - grub-firmware-qemu
+  - hdmi2usb-fx2-firmware
+  - sigrok-firmware-fx2lafw

--- a/wardrobe.d/accessories/firmwares/printers/index.yml
+++ b/wardrobe.d/accessories/firmwares/printers/index.yml
@@ -1,0 +1,56 @@
+# printers
+---
+name: firmwares
+description: "install firmware"
+author: artisan
+release: 0.0.1
+applyTo: all
+distroId: Debian
+codenameId: bullseye
+releaseId: stable
+sequence:
+  packages:
+  - autoconf
+  - avahi-utils
+  - colord
+  - cups
+  - cups-bsd
+  - cups-client
+  - cups-filters
+  - cups-pdf
+  - cups-pdf
+  - cups-ppdc
+  - dc
+  - foomatic-db-compressed-ppds
+  - ghostscript-cups
+  - ghostscript-x
+  - gocr-tk
+  - gutenprint-locales
+  - ink
+  - libtool
+  - openprinting-ppds
+  - printer-driver-all
+  - printer-driver-brlaser
+  - printer-driver-c2050
+  - printer-driver-c2esp
+  - printer-driver-cjet
+  - printer-driver-cups-pdf
+  - printer-driver-dymo
+  - printer-driver-escpr
+  - printer-driver-fujixerox
+  - printer-driver-gutenprint
+  - printer-driver-m2300w
+  - printer-driver-min12xxw
+  - printer-driver-pnm2ppa
+  - printer-driver-ptouch
+  - printer-driver-pxljr
+  - printer-driver-sag-gdi
+  - printer-driver-splix
+  - sane
+  - sane-utils
+  - system-config-printer
+  - system-config-printer-udev
+  - system-config-printer-udev
+  - tix
+  - unpaper
+  - xsltproc

--- a/wardrobe.d/accessories/firmwares/video-amd/index.yml
+++ b/wardrobe.d/accessories/firmwares/video-amd/index.yml
@@ -1,0 +1,19 @@
+# drivers-video-amd
+---
+name: firmwares
+description: "install drivers-video-amd"
+author: artisan
+release: 0.0.1
+applyTo: all
+distroId: Debian
+codenameId: bullseye
+releaseId: stable
+sequence:
+  drivers_video_amd:
+    - libdrm-amdgpu1
+    - libvulkan1
+    - mesa-opencl-icd
+    - mesa-vulkan-drivers
+    - vulkan-tools
+    - vulkan-validationlayers
+    - xserver-xorg-video-amdgpu

--- a/wardrobe.d/accessories/firmwares/video-nvidia/index.yml
+++ b/wardrobe.d/accessories/firmwares/video-nvidia/index.yml
@@ -1,0 +1,13 @@
+# driver-nvidia
+---
+name: driver-nvidia
+description: "install driver-nvidia"
+author: artisan
+release: 0.0.1
+applyTo: all
+distroId: Debian
+codenameId: bullseye
+releaseId: stable
+sequence:
+  package:
+  - bumblebee

--- a/wardrobe.d/external.yml
+++ b/wardrobe.d/external.yml
@@ -1,5 +1,5 @@
 wardrobes:
-  - authot: artisan,
+  - author: artisan,
     url: https://github.com/pieroproietti/penguins-wardrobe,
     description: Some examples from the author of eggs
   - authot: electrikjesus,

--- a/wardrobe.d/hen/index.yml
+++ b/wardrobe.d/hen/index.yml
@@ -51,8 +51,8 @@ sequence:
     - xfdesktop4
     - xfwm4
   accessories:
-    - base
-    - eggs-dev
+    # base
+    # eggs-dev
     - firmwares
   debs: false
   dirs: false


### PR DESCRIPTION
### eggs-9.1.0-1

A breacking news!

* wardrobe: after a bit of consolidation, I moved the suddivision of firmwares from the code to the wardrobe organization. ```firmwares``` now is a accessory with same own internal accessories. 
* accessories: now accessories can be external and internal. Internal accessories live inside the costume, for example  inside firmwares live codecs, network-cable and so on. Internal accessories have suffix: ```./```: ```./codecs```, ```./network-cable```, etc.
* If you open ```wardrobe.d/accessories/firmwares```, you can find inside: codecs, network-cable, printers, video-nvidia, network-wifi, video-amd and ou are free to add others. 

This result in a great semplification of code and a improved organization. Just adding others firmware categories inside firmwares - such graphics-tables - add an index.yml with the packages you needs; note: if your packages need a specific repo, you can add it too. Add your new accessory on index.yml of firmares and eggs will load it, add the request repos then install yours packages.
