### PR TITLE
PXE UEFI/BIOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ DESCRIPTION
   adapt monitor resolution for VM only
 ```
 
-_See code: [src/commands/adapt.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.4/src/commands/adapt.ts)_
+_See code: [src/commands/adapt.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.5/src/commands/adapt.ts)_
 
 ## `eggs analyze`
 
@@ -218,7 +218,7 @@ EXAMPLES
   $ sudo eggs analyze
 ```
 
-_See code: [src/commands/analyze.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.4/src/commands/analyze.ts)_
+_See code: [src/commands/analyze.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.5/src/commands/analyze.ts)_
 
 ## `eggs autocomplete [SHELL]`
 
@@ -276,7 +276,7 @@ EXAMPLES
   install calamares and create it's configuration's files
 ```
 
-_See code: [src/commands/calamares.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.4/src/commands/calamares.ts)_
+_See code: [src/commands/calamares.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.5/src/commands/calamares.ts)_
 
 ## `eggs config`
 
@@ -300,7 +300,7 @@ EXAMPLES
   Configure and install prerequisites deb packages to run it
 ```
 
-_See code: [src/commands/config.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.4/src/commands/config.ts)_
+_See code: [src/commands/config.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.5/src/commands/config.ts)_
 
 ## `eggs cuckoo`
 
@@ -323,7 +323,7 @@ EXAMPLES
   start a PXE boot server
 ```
 
-_See code: [src/commands/cuckoo.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.4/src/commands/cuckoo.ts)_
+_See code: [src/commands/cuckoo.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.5/src/commands/cuckoo.ts)_
 
 ## `eggs dad`
 
@@ -343,7 +343,7 @@ DESCRIPTION
   ask help from daddy - configuration helper
 ```
 
-_See code: [src/commands/dad.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.4/src/commands/dad.ts)_
+_See code: [src/commands/dad.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.5/src/commands/dad.ts)_
 
 ## `eggs export deb`
 
@@ -441,7 +441,7 @@ EXAMPLES
   Install the system using krill installer
 ```
 
-_See code: [src/commands/install.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.4/src/commands/install.ts)_
+_See code: [src/commands/install.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.5/src/commands/install.ts)_
 
 ## `eggs kill`
 
@@ -463,7 +463,7 @@ EXAMPLES
   kill the eggs/free the nest
 ```
 
-_See code: [src/commands/kill.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.4/src/commands/kill.ts)_
+_See code: [src/commands/kill.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.5/src/commands/kill.ts)_
 
 ## `eggs mom`
 
@@ -480,7 +480,7 @@ DESCRIPTION
   ask for mommy - gui helper
 ```
 
-_See code: [src/commands/mom.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.4/src/commands/mom.ts)_
+_See code: [src/commands/mom.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.5/src/commands/mom.ts)_
 
 ## `eggs produce`
 
@@ -542,7 +542,7 @@ EXAMPLES
   in /home/eggs/ovarium and you can customize all you need
 ```
 
-_See code: [src/commands/produce.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.4/src/commands/produce.ts)_
+_See code: [src/commands/produce.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.5/src/commands/produce.ts)_
 
 ## `eggs status`
 
@@ -560,7 +560,7 @@ DESCRIPTION
   informations about eggs status
 ```
 
-_See code: [src/commands/status.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.4/src/commands/status.ts)_
+_See code: [src/commands/status.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.5/src/commands/status.ts)_
 
 ## `eggs syncfrom`
 
@@ -584,7 +584,7 @@ EXAMPLES
   $ sudo eggs restore
 ```
 
-_See code: [src/commands/syncfrom.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.4/src/commands/syncfrom.ts)_
+_See code: [src/commands/syncfrom.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.5/src/commands/syncfrom.ts)_
 
 ## `eggs syncto`
 
@@ -607,7 +607,7 @@ EXAMPLES
   $ sudo eggs syncto
 ```
 
-_See code: [src/commands/syncto.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.4/src/commands/syncto.ts)_
+_See code: [src/commands/syncto.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.5/src/commands/syncto.ts)_
 
 ## `eggs tools clean`
 
@@ -702,7 +702,7 @@ EXAMPLES
   update/upgrade the penguin's eggs tool
 ```
 
-_See code: [src/commands/update.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.4/src/commands/update.ts)_
+_See code: [src/commands/update.ts](https://github.com/pieroproietti/penguins-eggs/blob/v9.2.5/src/commands/update.ts)_
 
 ## `eggs version`
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ You can read more on the [blog](https://penguins-eggs.net/2021/11/02/distros-tha
 
 # Features
 
+## cuckoo
+The cuckoo lays its eggs in the nests of other birds, and the eggs are hatched by the latter. Similarly eggs can start a self-configuring PXE service to allow you to boot and install your iso on third party networked computers. Command cuckoo can be used either to deploy a newly created iso on an installed system or by live booting the iso itself. 
+
 ## helper: mom and dad
 I've added two lightweight assistants integrated with eggs: mom and dad. While mom is a bash script with whiptail - and guides the user to the various commands and documentation, dad started as a short way to create isos. All you have to do is type **sudo eggs dad** and follow simple instructions. You can also shortcut the way to reset the configuration **sudo dad -c** or - even faster - reset the configuration, load defaults, kill created isos: simply type **sudo eggs dad -d** and you will immediately be able to produce the egg in the default /home/eggs nest.
 
@@ -62,9 +65,6 @@ We have two methods to save in the live system all our data: clone and backup.
 
 **NOTE:** 
 Using ```sudo eggs install``` will automaticaly restore your CRYPTED backup automatically. Of course the original passphrase will be request.
-
-## cuckoo
-The cuckoo lays its eggs in the nests of other birds, and the eggs are hatched by the latter. Similarly eggs can start a self-configuring PXE service to allow you to boot and install your iso on third party networked computers. Command cuckoo can be used either to deploy a newly created iso on an installed system or by live booting the iso itself. 
 
 ## yolk 
 yolk - so called staying on the subject of eggs - is a local repository included in the livecd that contains a minimum of indispensable packages during installation. Thanks to yolk, you can safely install your system without the need of an active internet connection. Yolk, It is used only for Debian families and derivated.

--- a/README.md
+++ b/README.md
@@ -48,9 +48,6 @@ You can read more on the [blog](https://penguins-eggs.net/2021/11/02/distros-tha
 ## cuckoo
 The cuckoo lays its eggs in the nests of other birds, and the eggs are hatched by the latter. Similarly eggs can start a self-configuring PXE service to allow you to boot and install your iso on third party networked computers. Command cuckoo can be used either to deploy a newly created iso on an installed system or by live booting the iso itself. 
 
-## helper: mom and dad
-I've added two lightweight assistants integrated with eggs: mom and dad. While mom is a bash script with whiptail - and guides the user to the various commands and documentation, dad started as a short way to create isos. All you have to do is type **sudo eggs dad** and follow simple instructions. You can also shortcut the way to reset the configuration **sudo dad -c** or - even faster - reset the configuration, load defaults, kill created isos: simply type **sudo eggs dad -d** and you will immediately be able to produce the egg in the default /home/eggs nest.
-
 ## backup/clone
 
 We have two methods to save in the live system all our data: clone and backup.
@@ -59,18 +56,21 @@ We have two methods to save in the live system all our data: clone and backup.
 
 ```eggs produces --fast --backup``` saves our data within the generated iso using a LUKS volume. Our data will NOT be visible in the live system but can be reinstalled automatically with krill installer. Even having the generated image available, our data will be protected by the LUKS passphrase.
 
-* ```eggs produce``` just users accounts and homes.
+* ```eggs produce``` this is the default: all private data are removed on the live.
 * ```eggs produce --clone``` include all users data UNCRYPTED directly on the live.
 * ```eggs produce --backup``` include all users data CRYPTED on a LUKS volume inside the iso.
 
-**NOTE:** 
-Using ```sudo eggs install``` will automaticaly restore your CRYPTED backup automatically. Of course the original passphrase will be request.
+Using ```sudo eggs install --cli``` will automaticaly restore your CRYPTED backup automatically during the installation.
 
 ## yolk 
 yolk - so called staying on the subject of eggs - is a local repository included in the livecd that contains a minimum of indispensable packages during installation. Thanks to yolk, you can safely install your system without the need of an active internet connection. Yolk, It is used only for Debian families and derivated.
 
-## krill installer
-eggs include a CLI installer named krill, this let you to produce and install servers configurations. krill use a nice TUI interface using the same, configuration created by eggs for [calamares](calamares.io). This lead to have "about the same" experience installing, from old distros to new ones and for GUI and CLI. It's possible with krill to do unattended installations, simply add ```--unattended``` flag and the values in ```/etc/penguins-eggs.d/krill.yaml``` will be used for installation.
+## GUI calamares or TUI krill installer
+eggs include a TUI installer named krill, this let you to produce and install servers configurations. krill use a nice TUI interface using the same, configuration created by eggs for [calamares](calamares.io). This lead to have "about the same" experience installing, from old distros to new ones and for GUI and CLI. It's possible with krill to do unattended installations, simply add ```--unattended``` flag and the values in ```/etc/penguins-eggs.d/krill.yaml``` will be used for installation.
+
+## helper: mom and dad
+I've added two lightweight assistants integrated with eggs: mom and dad. While mom is a bash script with whiptail - and guides the user to the various commands and documentation, dad started as a short way to create isos. All you have to do is type **sudo eggs dad** and follow simple instructions. You can also shortcut the way to reset the configuration **sudo dad -c** or - even faster - reset the configuration, load defaults, kill created isos: simply type **sudo eggs dad -d** and you will immediately be able to produce the egg in the default /home/eggs nest.
+
 
 ## addons and themes
 Addons are used mostly to let third parties to develop extensions. Note that currently we have an extension for the theme that includes both branding calamares, link and installer icon. In addition, also as an addon has been developed choose between GUI or CLI installation, adapt the video resolution, link to remote support, etc.

--- a/README.md
+++ b/README.md
@@ -308,11 +308,11 @@ cuckoo start a PXE boot server serving the live image
 
 ```
 USAGE
-  $ eggs cuckoo [-f] [-h] [-v]
+  $ eggs cuckoo [-r] [-h] [-v]
 
 FLAGS
-  -f, --full
   -h, --help     Show CLI help.
+  -r, --real     start a real dhcp server
   -v, --verbose  verbose
 
 DESCRIPTION

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,11 @@ You can follow the project also consulting the [commit history](https://github.c
 ## Changelog
 Versions are listed on reverse order, the first is the last one. Old versions are moved to [versions](https://sourceforge.net/projects/penguins-eggs/files/packages-deb/versions/). 
 
+### eggs-9.2.5
+```cuckoo``` since version **eggs-9.2.5**, 16 on **september 2022**, is capable to boot BIOS and UEFI machines, however due to a bug in slim package, using sudo eggs cuckoo in dhcp-proxy version will not get UEFI machines to boot. Instead, use: sudo eggs cuckoo --real. 
+
+__Warning__: using ``eggs cuckpp --real`` adds additional dhcp to the network, this may lead to problems or be prohibited by your organization,
+
 ### eggs-9.2.4
 Added a new command: ```sudo eggs cuckoo```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "penguins-eggs",
     "description": "Perri's Brewery edition: remaster your system and distribuite it",
-    "version": "9.2.4",
+    "version": "9.2.5",
     "author": "Piero Proietti @pieroproietti",
     "bin": {
         "eggs": "bin/run"

--- a/scripts/_eggs
+++ b/scripts/_eggs
@@ -11,7 +11,7 @@ _eggs () {
 "analyze:analyze for syncto"
 "calamares:calamares or install or configure it"
 "config:Configure and install prerequisites deb packages to run it"
-"cuckoo:cuckoo start a boot server on the LAN sharing iso on the nest"
+"cuckoo:cuckoo start a PXE boot server serving the live image"
 "dad:ask help from daddy - configuration helper"
 "export\:deb:export deb/docs/iso to the destination host"
 "export\:docs:remove and export docType documentation of the sources in the destination host"
@@ -33,8 +33,8 @@ _eggs () {
 "wardrobe\:list:list costumes and accessoires in wardrobe"
 "wardrobe\:show:show costumes/accessories in wardrobe"
 "wardrobe\:wear:wear costume/accessories from wardrobe"
-"help:Display help for <%= config.bin %>."
 "autocomplete:display autocomplete installation instructions"
+"help:Display help for <%= config.bin %>."
 "version:"
   )
 
@@ -76,7 +76,8 @@ config)
 
 cuckoo)
   _command_flags=(
-    "--help[Show CLI help.]"
+    "--real[start a real dhcp server]"
+"--help[Show CLI help.]"
 "--verbose[verbose]"
   )
 ;;
@@ -263,15 +264,15 @@ wardrobe:wear)
   )
 ;;
 
-help)
-  _command_flags=(
-    "--nested-commands[Include all nested commands in the output.]"
-  )
-;;
-
 autocomplete)
   _command_flags=(
     "--refresh-cache[Refresh cache (ignores displaying instructions)]"
+  )
+;;
+
+help)
+  _command_flags=(
+    "--nested-commands[Include all nested commands in the output.]"
   )
 ;;
 

--- a/scripts/eggs.bash
+++ b/scripts/eggs.bash
@@ -15,7 +15,7 @@ adapt --verbose --help
 analyze --help --verbose
 calamares --help --verbose --install --release --remove --theme
 config --nointeractive --clean --help --verbose
-cuckoo --help --verbose
+cuckoo --real --help --verbose
 dad --help --clean --default --verbose
 export:deb --help --clean --amd64 --i386 --armel --arm64 --all
 export:docs --help
@@ -37,8 +37,8 @@ wardrobe:ironing --wardrobe --verbose --help
 wardrobe:list --verbose --help
 wardrobe:show --wardrobe --json --verbose --help
 wardrobe:wear --wardrobe --no_accessories --no_firmwares --silent --verbose --help
-help --nested-commands
 autocomplete --refresh-cache
+help --nested-commands
 version --json --verbose
 "
 

--- a/scripts/netgrub.sh
+++ b/scripts/netgrub.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -e
+
+# Sets up a tftp server to netboot x86_64 systems over UEFI.
+# Works on Ubuntu 13.10 and later.
+
+# change to the root of your tftp server
+TFTPROOT=/var/lib/tftpboot
+
+# needed for unpacking the shim-signed source package
+apt-get install dpkg-dev
+
+tmpdir=$(mktemp -d)
+
+cleanup () {
+	if [ -n "$tmpdir" ]; then
+		rm -rf "$tmpdir"
+	fi
+}
+
+trap cleanup EXIT HUP INT QUIT PIPE TERM
+
+cd "$tmpdir"
+apt-get source shim-signed
+cp shim-signed-*/shim.efi.signed "$TFTPROOT"/bootx64.efi
+
+cd "$TFTPROOT"
+
+wget -O grubx64.efi http://archive.ubuntu.com/ubuntu/dists/saucy/main/uefi/grub2-amd64/current/grubnetx64.efi.signed
+
+# Unfortunately the unicode font is assembled by the grub2 package at
+# build-time, so we can't grab it from the source; and we have no persistent
+# URL for it since that changes with each version number; so try to install
+# it (which should be a no-op on x86 anyway) and copy the contents.
+apt-get install grub-common
+mkdir -p grub/fonts
+cp /usr/share/grub/unicode.pf2 grub/fonts
+

--- a/sourceforge/files/DEBS/testing/README.md
+++ b/sourceforge/files/DEBS/testing/README.md
@@ -26,10 +26,11 @@ The cuckoo lays its eggs in the nests of other birds, and the eggs are hatched b
 
 This is the first implementation of cuckoo, based on dnsmasq. I would have liked to implement it interament in node, so far it has not been possible.
 
-Given the need to install the dnsmaq and pxelinux packages cuckoo is currently only available for Debian/Devuan/Ubuntu. I plan to externalize its compatibility to manjaro and Arch distributions soon.
+Given the need to install the dnsmaq and pxelinux packages cuckoo is currently only available for Debian/Devuan/Ubuntu. I plan to extend its compatibility to manjaro and Arch distributions soon.
+
+cuckoo since version eggs-9.2.5 september 2022, is capable to boot BIOS and UEFI machines, however due to a bug in [slim](https://github.com/rhboot/shim/issues/165) package, using ```sudo eggs cuckoo``` in dhcp-proxy version will not get the machines to boot. Instead, use: sudo eggs cuckoo --real.
 
 # TO DO
 
-* add UEFI capabilities
 * add Arch and manjaro compatibility
 

--- a/sourceforge/files/DEBS/testing/README.md
+++ b/sourceforge/files/DEBS/testing/README.md
@@ -28,9 +28,10 @@ This is the first implementation of cuckoo, based on dnsmasq. I would have liked
 
 Given the need to install the dnsmaq and pxelinux packages cuckoo is currently only available for Debian/Devuan/Ubuntu. I plan to extend its compatibility to manjaro and Arch distributions soon.
 
-cuckoo since version eggs-9.2.5 september 2022, is capable to boot BIOS and UEFI machines, however due to a bug in [slim](https://github.com/rhboot/shim/issues/165) package, using ```sudo eggs cuckoo``` in dhcp-proxy version will not get the machines to boot. Instead, use: sudo eggs cuckoo --real.
+cuckoo since version eggs-9.2.5 september 2022, is capable to boot BIOS and UEFI machines, however due to a bug in [slim](https://github.com/rhboot/shim/issues/165) package, using ```sudo eggs cuckoo``` in dhcp-proxy version will not get the machines to boot. Instead, use: ```sudo eggs cuckoo --real```.
 
 # TO DO
 
-* add Arch and manjaro compatibility
+* minor cleaning;
+* add Arch and manjaro compatibility.
 

--- a/src/classes/ovary.ts
+++ b/src/classes/ovary.ts
@@ -1564,6 +1564,7 @@ export default class Ovary {
     file = dotDisk + '/mkisofs'
     fs.writeFileSync(file, content, 'utf-8')
     return content
+
   }
 
   /**

--- a/src/classes/pxe.ts
+++ b/src/classes/pxe.ts
@@ -180,8 +180,12 @@ export default class Pxe {
       
         grubContent += `menuentry '${this.bootLabel}' {\n`
         grubContent += `  gfxmode $linux_gfx_mode\n`
-        grubContent += `  linux http://${Utils.address()}/live/${this.vmlinuz}\n`
-        grubContent += `  initrd http://${Utils.address()}/live/${this.initrd} boot=live config noswap noprompt fetch=http://${Utils.address()}/live/filesystem.squashfs\n`
+        // grubContent += `  linux http://${Utils.address()}/live/${this.vmlinuz}\n`
+        // grubContent += `  initrd http://${Utils.address()}/live/${this.initrd} boot=live config noswap noprompt fetch=http://${Utils.address()}/live/filesystem.squashfs\n`
+        grubContent += `  linux (http) ${Utils.address()}/live/${this.vmlinuz}\n`
+        grubContent += `  initrd (http) ${Utils.address()}/live/${this.initrd}\n`
+        // grubContent += `  append boot=live config noswap noprompt fetch=http://${Utils.address()}/live/filesystem.squashfs\n`
+
         grubContent += `}\n`
         let grubFile = `${this.pxeRoot}grub/grub.cfg`
         fs.writeFileSync(grubFile, grubContent)

--- a/src/classes/pxe.ts
+++ b/src/classes/pxe.ts
@@ -129,7 +129,9 @@ export default class Pxe {
             await this.tryCatch(`ln -s /usr/share/grub/unicode.pf2 ${this.pxeRoot}/grub/fonts/unicode.pf2`)
         }
 
-        // creating /grub.cfg, /grub/grub.cfg and /grub/x86_64-efi/grub.cfg
+        /**
+         * creating /grub/grub.cfg
+         */
         let grubContent = ''
         grubContent += `set default="0"\n`
         grubContent += `set timeout=-1\n`
@@ -179,7 +181,6 @@ export default class Pxe {
         grubContent += `  linux http://${Utils.address()}/live/${this.vmlinuz}\n`
         grubContent += `  initrd http://${Utils.address()}/live/${this.initrd} boot=live config noswap noprompt fetch=http://${Utils.address()}/live/filesystem.squashfs\n`
         grubContent += `}\n`
-
         let grubFile = `${this.pxeRoot}grub/grub.cfg`
         fs.writeFileSync(grubFile, grubContent)
 
@@ -259,7 +260,7 @@ export default class Pxe {
     /**
      * 
      */
-    async dnsMasq(full = false) {
+    async dnsMasq(real = false) {
         await exec(`systemctl stop dnsmasq.service`)
 
         let domain = `penguins-eggs.lan`
@@ -298,10 +299,10 @@ export default class Pxe {
          */
         content += `pxe-service=X86PC,"penguin's eggs cuckoo",pxelinux.0\n`
 
-        if (full) {
+        if (real) {
             content += `dhcp-range=${await Utils.iface()},${n.first},${n.last},${n.mask},8h\n`
         } else {
-            content += `dhcp-range=${await Utils.iface()},${n.base},proxy,${n.mask},${Utils.broadcast()} # dhcp proxy\n`
+            content += `dhcp-range=${await Utils.iface()},${n.base},proxy,${n.mask},${n.broadcast} # dhcp proxy\n`
         }
 
         let file = '/etc/dnsmasq.d/cuckoo.conf'

--- a/src/classes/pxe.ts
+++ b/src/classes/pxe.ts
@@ -117,11 +117,9 @@ export default class Pxe {
         await this.tryCatch(`ln -s ${this.isoRoot}.disk ${this.pxeRoot}/.disk`)
 
         // UEFI:                   /usr/lib/shim/shimx64.efi.signed
-        // await this.tryCatch(`ln -s /usr/lib/shim/shimx64.efi.signed ${this.pxeRoot}/bootx64.efi`)
-        await this.tryCatch(`cp /usr/lib/shim/shimx64.efi.signed ${this.pxeRoot}/bootx64.efi`)
+        await this.tryCatch(`ln -s /usr/lib/shim/shimx64.efi.signed ${this.pxeRoot}/bootx64.efi`)
         // UEFI:                   /usr/lib/grub/x86_64-efi-signed/grubnetx64.efi.signed
-        // await this.tryCatch(`ln -s /usr/lib/grub/x86_64-efi-signed/grubnetx64.efi.signed ${this.pxeRoot}/grubx64.efi`)
-        await this.tryCatch(`cp /usr/lib/grub/x86_64-efi-signed/grubnetx64.efi.signed ${this.pxeRoot}/grubx64.efi`)
+        await this.tryCatch(`ln -s /usr/lib/grub/x86_64-efi-signed/grubnetx64.efi.signed ${this.pxeRoot}/grubx64.efi`)
 
         // unicode.pf2 installed as grub/fonts/unicode.pf2
         await this.tryCatch(`mkdir ${this.pxeRoot}grub/fonts -p`)
@@ -131,7 +129,7 @@ export default class Pxe {
             await this.tryCatch(`ln -s /usr/share/grub/unicode.pf2 ${this.pxeRoot}/grub/fonts/unicode.pf2`)
         }
 
-        // creating grub/grub.cfg
+        // creating /grub.cfg, /grub/grub.cfg and /grub/x86_64-efi/grub.cfg
         let grubContent = ''
         grubContent += `set default="0"\n`
         grubContent += `set timeout=-1\n`
@@ -183,11 +181,11 @@ export default class Pxe {
         grubContent += `}\n`
 
         // look in /grub/grub.cfg or /grub/x86_64-efi/grub.cfg 
-        let grubFile = `${this.pxeRoot}grub.cfg`
-        fs.writeFileSync(grubFile, grubContent)
-        grubFile = `${this.pxeRoot}grub/grub.cfg`
-        fs.writeFileSync(grubFile, grubContent)
-        grubFile = `${this.pxeRoot}grub/x86_64-efi/grub.cfg`
+        // let grubFile = `${this.pxeRoot}grub.cfg`
+        // fs.writeFileSync(grubFile, grubContent)
+        // grubFile = `${this.pxeRoot}grub/grub.cfg`
+        // fs.writeFileSync(grubFile, grubContent)
+        let grubFile = `${this.pxeRoot}grub/x86_64-efi/grub.cfg`
         fs.writeFileSync(grubFile, grubContent)
 
         // isolinux.theme.cfg, splash.png MUST to be on root

--- a/src/classes/pxe.ts
+++ b/src/classes/pxe.ts
@@ -180,12 +180,7 @@ export default class Pxe {
         grubContent += `  initrd http://${Utils.address()}/live/${this.initrd} boot=live config noswap noprompt fetch=http://${Utils.address()}/live/filesystem.squashfs\n`
         grubContent += `}\n`
 
-        // look in /grub/grub.cfg or /grub/x86_64-efi/grub.cfg 
-        // let grubFile = `${this.pxeRoot}grub.cfg`
-        // fs.writeFileSync(grubFile, grubContent)
-        // grubFile = `${this.pxeRoot}grub/grub.cfg`
-        // fs.writeFileSync(grubFile, grubContent)
-        let grubFile = `${this.pxeRoot}grub/x86_64-efi/grub.cfg`
+        let grubFile = `${this.pxeRoot}grub/grub.cfg`
         fs.writeFileSync(grubFile, grubContent)
 
         // isolinux.theme.cfg, splash.png MUST to be on root
@@ -269,6 +264,7 @@ export default class Pxe {
 
         let domain = `penguins-eggs.lan`
         let n = new Netmask(`${Utils.address()}/${Utils.netmask()}`)
+        console.log(n)
 
         let content = ``
         content += `# cuckoo.conf\n`
@@ -306,7 +302,7 @@ export default class Pxe {
         if (full) {
             content += `dhcp-range=${await Utils.iface()},${n.first},${n.last},${n.mask},8h\n`
         } else {
-            content += `dhcp-range=${await Utils.iface()},${Utils.address()},proxy,${n.mask},${Utils.broadcast()} # dhcp proxy\n`
+            content += `dhcp-range=${await Utils.iface()},${n.base},proxy,${n.mask},${Utils.broadcast()} # dhcp proxy\n`
         }
 
         let file = '/etc/dnsmasq.d/cuckoo.conf'

--- a/src/classes/pxe.ts
+++ b/src/classes/pxe.ts
@@ -162,15 +162,15 @@ export default class Pxe {
         grubContent += `\n`
 
         grubContent += `if loadfont $prefix/font.pf2 ; then\n`
-        grubContent += `set gfxmode=640x480\n`
-        grubContent += `insmod efi_gop\n`
-        grubContent += `insmod efi_uga\n`
-        grubContent += `insmod video_bochs\n`
-        grubContent += `insmod video_cirrus\n`
-        grubContent += `insmod gfxterm\n`
-        grubContent += `insmod jpeg\n`
-        grubContent += `insmod png\n`
-        grubContent += `terminal_output gfxterm\n`
+        grubContent += `  set gfxmode=640x480\n`
+        grubContent += `  insmod efi_gop\n`
+        grubContent += `  insmod efi_uga\n`
+        grubContent += `  insmod video_bochs\n`
+        grubContent += `  insmod video_cirrus\n`
+        grubContent += `  insmod gfxterm\n`
+        grubContent += `  insmod jpeg\n`
+        grubContent += `  insmod png\n`
+        grubContent += `  terminal_output gfxterm\n`
         grubContent += `fi\n`
         grubContent += `set theme=/boot/grub/theme.cfg\n`
       
@@ -264,7 +264,6 @@ export default class Pxe {
 
         let domain = `penguins-eggs.lan`
         let n = new Netmask(`${Utils.address()}/${Utils.netmask()}`)
-        console.log(n)
 
         let content = ``
         content += `# cuckoo.conf\n`

--- a/src/classes/pxe.ts
+++ b/src/classes/pxe.ts
@@ -247,13 +247,11 @@ export default class Pxe {
  
            
             grubContent += `menuentry '${this.bootLabel}' {\n`
-            // grubContent += `  gfxmode $linux_gfx_mode\n`
-            grubContent += `  set gfxpayload=keep\n`
-            
-            // grubContent += `  linux http://${Utils.address()}/live/${this.vmlinuz}\n`
-            // grubContent += `  initrd http://${Utils.address()}/live/${this.initrd} boot=live config noswap noprompt fetch=http://${Utils.address()}/live/filesystem.squashfs\n`
-            grubContent += `  linux vmlinuz quiet splash\n`
-            grubContent += `  initrd initrd boot=live config noswap noprompt fetch=http://${Utils.address()}/live/filesystem.squashfs\n`
+            grubContent += `  gfxmode $linux_gfx_mode\n`
+            // grubContent += `  set gfxpayload=keep\n`
+            grubContent += `  linuxefi vmlinuz  boot=live config noswap noprompt fetch=http://${Utils.address()}/live/filesystem.squashfs quiet splash\n`
+            grubContent += `  initrdefi initrd \n`
+            grubContent += `  SYSAPPEND 3\n`
     
             grubContent += `}\n`
             let grubFile = `${this.pxeRoot}grub/grub.cfg`

--- a/src/classes/pxe.ts
+++ b/src/classes/pxe.ts
@@ -116,18 +116,20 @@ export default class Pxe {
         await this.tryCatch(`ln -s ${this.isoRoot}live ${this.pxeRoot}/live`)
         await this.tryCatch(`ln -s ${this.isoRoot}.disk ${this.pxeRoot}/.disk`)
 
+
+        await this.tryCatch(`mkdir ${this.pxeRoot}/grub`)
+        if (fs.existsSync('/usr/share/grub/unicode.pf2')) {
+            await this.tryCatch(`ln -s /usr/share/grub/unicode.pf2 ${this.pxeRoot}grub/font.pf2`)
+        }
+
         // UEFI:                   /usr/lib/shim/shimx64.efi.signed
         await this.tryCatch(`ln -s /usr/lib/shim/shimx64.efi.signed ${this.pxeRoot}/bootx64.efi`)
         // UEFI:                   /usr/lib/grub/x86_64-efi-signed/grubnetx64.efi.signed
         await this.tryCatch(`ln -s /usr/lib/grub/x86_64-efi-signed/grubnetx64.efi.signed ${this.pxeRoot}/grubx64.efi`)
 
-        // unicode.pf2 installed as grub/fonts/unicode.pf2
-        await this.tryCatch(`mkdir ${this.pxeRoot}grub/fonts -p`)
-        await this.tryCatch(`mkdir ${this.pxeRoot}grub/x86_64-efi -p`)
-
-        if (fs.existsSync('/usr/share/grub/unicode.pf2')) {
-            await this.tryCatch(`ln -s /usr/share/grub/unicode.pf2 ${this.pxeRoot}/grub/fonts/unicode.pf2`)
-        }
+        // Copia spash.png, theme.cfg in /grub
+        await this.tryCatch(`ln -s ${this.isoRoot}boot/grub/splash.png ${this.pxeRoot}/grub/splash.png`)
+        await this.tryCatch(`ln -s ${this.isoRoot}boot/grub/theme.cfg ${this.pxeRoot}/grub/theme.cfg`)
 
         /**
          * creating /grub/grub.cfg
@@ -174,7 +176,7 @@ export default class Pxe {
         grubContent += `  insmod png\n`
         grubContent += `  terminal_output gfxterm\n`
         grubContent += `fi\n`
-        grubContent += `set theme=/boot/grub/theme.cfg\n`
+        grubContent += `set theme=/grub/theme.cfg\n`
       
         grubContent += `menuentry '${this.bootLabel}' {\n`
         grubContent += `  gfxmode $linux_gfx_mode\n`

--- a/src/classes/pxe.ts
+++ b/src/classes/pxe.ts
@@ -248,10 +248,8 @@ export default class Pxe {
            
             grubContent += `menuentry '${this.bootLabel}' {\n`
             grubContent += `  gfxmode $linux_gfx_mode\n`
-            // grubContent += `  set gfxpayload=keep\n`
-            grubContent += `  linuxefi vmlinuz  boot=live config noswap noprompt fetch=http://${Utils.address()}/live/filesystem.squashfs quiet splash\n`
-            grubContent += `  initrdefi initrd \n`
-            grubContent += `  SYSAPPEND 3\n`
+            grubContent += `  linuxefi vmlinuz boot=live config noswap noprompt fetch=http://${Utils.address()}/live/filesystem.squashfs quiet splash sysappend 0x40000\n`
+            grubContent += `  initrdefi initrd\n`
     
             grubContent += `}\n`
             let grubFile = `${this.pxeRoot}grub/grub.cfg`

--- a/src/classes/pxe.ts
+++ b/src/classes/pxe.ts
@@ -94,10 +94,12 @@ export default class Pxe {
         this.bootLabel = c.substring(c.lastIndexOf('/') + 1)
     }
 
+
+
     /**
-     * structure
+     * build
      */
-    async structure() {
+    async build() {
 
         if (fs.existsSync(this.pxeRoot)) {
             await this.tryCatch(`rm ${this.pxeRoot} -rf`)
@@ -105,35 +107,34 @@ export default class Pxe {
         let cmd = `mkdir -p ${this.pxeRoot}`
         await this.tryCatch(cmd)
 
-        const distro = new Distro()
-
         await this.tryCatch(`mkdir ${this.pxeRoot} -p`)
-
-        // link boot, efi, isolinuxm live and .disk
-        // await this.tryCatch(`ln -s ${this.isoRoot}boot ${this.pxeRoot}/boot`)
-        // await this.tryCatch(`ln -s ${this.isoRoot}efi ${this.pxeRoot}/efi`)
-        await this.tryCatch(`ln -s ${this.isoRoot}isolinux ${this.pxeRoot}/isolinux`)
         await this.tryCatch(`ln -s ${this.isoRoot}live ${this.pxeRoot}/live`)
         await this.tryCatch(`ln -s ${this.isoRoot}.disk ${this.pxeRoot}/.disk`)
+        await this.tryCatch(`ln -s ${this.isoRoot}live/${this.vmlinuz} ${this.pxeRoot}/vmlinuz`)
+        await this.tryCatch(`chmod 777 ${this.pxeRoot}/vmlinuz`)
+        await this.tryCatch(`ln -s ${this.isoRoot}live/${this.initrd} ${this.pxeRoot}/initrd`)
+        await this.tryCatch(`chmod 777 ${this.pxeRoot}/initrd`)
 
-
-        await this.tryCatch(`mkdir ${this.pxeRoot}/grub`)
-        if (fs.existsSync('/usr/share/grub/unicode.pf2')) {
-            await this.tryCatch(`ln -s /usr/share/grub/unicode.pf2 ${this.pxeRoot}grub/font.pf2`)
+        // link iso images in pxe
+        for (const iso of this.isos) {
+            await this.tryCatch(`ln /home/eggs/${iso} ${this.pxeRoot}/${iso}`)
         }
+        await this.bios()
+        await this.uefi()
+        await this.html()
+    }
 
-        // UEFI:                   /usr/lib/shim/shimx64.efi.signed
-        await this.tryCatch(`ln -s /usr/lib/shim/shimx64.efi.signed ${this.pxeRoot}/bootx64.efi`)
-        // UEFI:                   /usr/lib/grub/x86_64-efi-signed/grubnetx64.efi.signed
-        await this.tryCatch(`ln -s /usr/lib/grub/x86_64-efi-signed/grubnetx64.efi.signed ${this.pxeRoot}/grubx64.efi`)
-
-        this.configureGrub()
+    /**
+     * configure PXE bios
+     */
+     async bios() {
 
         // isolinux.theme.cfg, splash.png MUST to be on root
         await this.tryCatch(`ln -s ${this.isoRoot}isolinux/isolinux.theme.cfg ${this.pxeRoot}/isolinux.theme.cfg`)
         await this.tryCatch(`ln -s ${this.isoRoot}isolinux/splash.png ${this.pxeRoot}/splash.png`)
 
         // pxe
+        const distro = this.settings.distro
         await this.tryCatch(`ln ${distro.pxelinuxPath}pxelinux.0 ${this.pxeRoot}/pxelinux.0`)
         await this.tryCatch(`ln ${distro.pxelinuxPath}lpxelinux.0 ${this.pxeRoot}/lpxelinux.0`)
 
@@ -145,22 +146,125 @@ export default class Pxe {
         await this.tryCatch(`ln /usr/lib/syslinux/memdisk ${this.pxeRoot}/memdisk`)
         await this.tryCatch(`mkdir ${this.pxeRoot}/pxelinux.cfg`)
 
-        // link iso images in pxe
-        for (const iso of this.isos) {
-            await this.tryCatch(`ln /home/eggs/${iso} ${this.pxeRoot}/${iso}`)
+        let content = ``
+        content += `# eggs: pxelinux.cfg/default\n`
+        content += `# search path for the c32 support libraries (libcom32, libutil etc.)\n`
+        content += `path\n`
+        content += `include isolinux.theme.cfg\n`
+        content += `UI vesamenu.c32\n`
+        content += `\n`
+        content += `menu title Penguin's eggs - Perri's brewery edition - ${Utils.address()}\n`
+        content += `PROMPT 0\n`
+        content += `TIMEOUT 0\n`
+        content += `\n`
+
+        content += `LABEL http\n`
+        content += `MENU LABEL ${this.bootLabel}\n`
+        content += `MENU DEFAULT\n`
+        content += `KERNEL http://${Utils.address()}/live/${this.vmlinuz}\n`
+        content += `APPEND initrd=http://${Utils.address()}/live/${this.initrd} boot=live config noswap noprompt fetch=http://${Utils.address()}/live/filesystem.squashfs\n`
+        content += `SYSAPPEND 3\n`
+        content += `\n`
+
+        if (this.isos.length > 0) {
+            content += `MENU SEPARATOR\n`
+            for (const iso of this.isos) {
+                content += `\n`
+                content += `LABEL isos\n`
+                content += `MENU LABEL memdisk ${iso}\n`
+                content += `KERNEL memdisk\n`
+                content += `APPEND iso initrd=http://${Utils.address()}/${iso}\n`
+            }
         }
-
-        this.configurePxelinux()
-
-
-        this.configureHtml()
-
+        let file = `${this.pxeRoot}/pxelinux.cfg/default`
+        fs.writeFileSync(file, content)
     }
 
     /**
-     * 
+     * configure PXE UEFI
      */
-    configureHtml() {
+         async uefi() {
+            await this.tryCatch(`mkdir ${this.pxeRoot}/grub`)
+            if (fs.existsSync('/usr/share/grub/unicode.pf2')) {
+                await this.tryCatch(`ln -s /usr/share/grub/unicode.pf2 ${this.pxeRoot}grub/font.pf2`)
+            }
+    
+            // Copia spash.png, theme.cfg in /grub
+            await this.tryCatch(`ln -s ${this.isoRoot}boot/grub/splash.png ${this.pxeRoot}/grub/splash.png`)
+            await this.tryCatch(`ln -s ${this.isoRoot}boot/grub/theme.cfg ${this.pxeRoot}/grub/theme.cfg`)
+    
+            // UEFI:                   /usr/lib/shim/shimx64.efi.signed
+            await this.tryCatch(`ln -s /usr/lib/shim/shimx64.efi.signed ${this.pxeRoot}/bootx64.efi`)
+            // UEFI:                   /usr/lib/grub/x86_64-efi-signed/grubnetx64.efi.signed
+            await this.tryCatch(`ln -s /usr/lib/grub/x86_64-efi-signed/grubnetx64.efi.signed ${this.pxeRoot}/grubx64.efi`)
+    
+            /**
+             * creating /grub/grub.cfg
+             */
+            let grubContent = ''
+            grubContent += `set default="0"\n`
+            grubContent += `set timeout=-1\n`
+            grubContent += `\n`
+            grubContent += `if loadfont unicode ; then\n`
+            grubContent += `  set gfxmode=auto\n`
+            grubContent += `  set locale_dir=$prefix/locale\n`
+            grubContent += `  set lang=en_US\n`
+            grubContent += `fi\n`
+            grubContent += `terminal_output gfxterm\n`
+            grubContent += `\n`
+            grubContent += `set menu_color_normal=white/black\n`
+            grubContent += `set menu_color_highlight=black/light-gray\n`
+            grubContent += `if background_color 44,0,30; then\n`
+            grubContent += `  clear\n`
+            grubContent += `fi\n`
+            grubContent += `\n`
+            grubContent += `function gfxmode {\n`
+            grubContent += `\n`
+            grubContent += `  set gfxpayload="${1}"\n`
+            grubContent += `  if [ "${1}" = "keep" ]; then\n`
+            grubContent += `    set vt_handoff=vt.handoff=7\n`
+            grubContent += `  else\n`
+            grubContent += `    set vt_handoff=\n`
+            grubContent += `  fi\n`
+            grubContent += `}\n`
+            grubContent += `set linux_gfx_mode=keep\n`
+            grubContent += `\n`
+            grubContent += `export linux_gfx_mode\n`
+            grubContent += `\n`
+    
+            grubContent += `if loadfont $prefix/font.pf2 ; then\n`
+            grubContent += `  set gfxmode=640x480\n`
+            grubContent += `  insmod efi_gop\n`
+            grubContent += `  insmod efi_uga\n`
+            grubContent += `  insmod video_bochs\n`
+            grubContent += `  insmod video_cirrus\n`
+            grubContent += `  insmod gfxterm\n`
+            grubContent += `  insmod jpeg\n`
+            grubContent += `  insmod png\n`
+            grubContent += `  terminal_output gfxterm\n`
+            grubContent += `fi\n`
+            grubContent += `set theme=/grub/theme.cfg\n`
+ 
+           
+            grubContent += `menuentry '${this.bootLabel}' {\n`
+            // grubContent += `  gfxmode $linux_gfx_mode\n`
+            grubContent += `  set gfxpayload=keep\n`
+            
+            // grubContent += `  linux http://${Utils.address()}/live/${this.vmlinuz}\n`
+            // grubContent += `  initrd http://${Utils.address()}/live/${this.initrd} boot=live config noswap noprompt fetch=http://${Utils.address()}/live/filesystem.squashfs\n`
+            grubContent += `  linux vmlinuz quiet splash\n`
+            grubContent += `  initrd initrd boot=live config noswap noprompt fetch=http://${Utils.address()}/live/filesystem.squashfs\n`
+    
+            grubContent += `}\n`
+            let grubFile = `${this.pxeRoot}grub/grub.cfg`
+            fs.writeFileSync(grubFile, grubContent)
+    
+        }
+    
+    /**
+     * configure PXE html
+     */
+    async html() {
 
         let file = `${this.pxeRoot}/index.html`
         let content = ``
@@ -180,10 +284,38 @@ export default class Pxe {
         fs.writeFileSync(file, content)
     }
 
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    //
+    // dncp: actually install and configure dnsmaq
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * 
+     * @param real 
+     */
+    async dhcp(real = false, dnsmasq = true) {
+        if (dnsmasq) {
+            await this.dnsmasq(real)
+        } else {
+            await this.nodeDhcp(real)
+        }
+    }
+
     /**
      * 
      */
-    async dnsMasq(real = false) {
+    private async nodeDhcp(real = false) {
+        console.log('to do!')
+        process.exit()
+    }
+
+
+    /**
+     * 
+     * @param real 
+     */
+    private async dnsmasq(real = false) {
         await exec(`systemctl stop dnsmasq.service`)
 
         let domain = `penguins-eggs.lan`
@@ -236,128 +368,6 @@ export default class Pxe {
     }
 
     /**
-    * 
-    * @param cmd 
-    */
-    async tryCatch(cmd = '') {
-        try {
-            await exec(cmd, this.echo)
-        } catch (error) {
-            console.log(`Error: ${error}`)
-            await Utils.pressKeyToExit(cmd)
-        }
-    }
-
-
-    /**
-     * 
-     */
-    async configureGrub() {
-        // Copia spash.png, theme.cfg in /grub
-        await this.tryCatch(`ln -s ${this.isoRoot}boot/grub/splash.png ${this.pxeRoot}/grub/splash.png`)
-        await this.tryCatch(`ln -s ${this.isoRoot}boot/grub/theme.cfg ${this.pxeRoot}/grub/theme.cfg`)
-
-        /**
-         * creating /grub/grub.cfg
-         */
-        let grubContent = ''
-        grubContent += `set default="0"\n`
-        grubContent += `set timeout=-1\n`
-        grubContent += `\n`
-        grubContent += `if loadfont unicode ; then\n`
-        grubContent += `  set gfxmode=auto\n`
-        grubContent += `  set locale_dir=$prefix/locale\n`
-        grubContent += `  set lang=en_US\n`
-        grubContent += `fi\n`
-        grubContent += `terminal_output gfxterm\n`
-        grubContent += `\n`
-        grubContent += `set menu_color_normal=white/black\n`
-        grubContent += `set menu_color_highlight=black/light-gray\n`
-        grubContent += `if background_color 44,0,30; then\n`
-        grubContent += `  clear\n`
-        grubContent += `fi\n`
-        grubContent += `\n`
-        grubContent += `function gfxmode {\n`
-        grubContent += `\n`
-        grubContent += `  set gfxpayload="${1}"\n`
-        grubContent += `  if [ "${1}" = "keep" ]; then\n`
-        grubContent += `    set vt_handoff=vt.handoff=7\n`
-        grubContent += `  else\n`
-        grubContent += `    set vt_handoff=\n`
-        grubContent += `  fi\n`
-        grubContent += `}\n`
-        grubContent += `set linux_gfx_mode=keep\n`
-        grubContent += `\n`
-        grubContent += `export linux_gfx_mode\n`
-        grubContent += `\n`
-
-        grubContent += `if loadfont $prefix/font.pf2 ; then\n`
-        grubContent += `  set gfxmode=640x480\n`
-        grubContent += `  insmod efi_gop\n`
-        grubContent += `  insmod efi_uga\n`
-        grubContent += `  insmod video_bochs\n`
-        grubContent += `  insmod video_cirrus\n`
-        grubContent += `  insmod gfxterm\n`
-        grubContent += `  insmod jpeg\n`
-        grubContent += `  insmod png\n`
-        grubContent += `  terminal_output gfxterm\n`
-        grubContent += `fi\n`
-        grubContent += `set theme=/grub/theme.cfg\n`
-
-        grubContent += `menuentry '${this.bootLabel}' {\n`
-        grubContent += `  gfxmode $linux_gfx_mode\n`
-        // grubContent += `  linux http://${Utils.address()}/live/${this.vmlinuz}\n`
-        // grubContent += `  initrd http://${Utils.address()}/live/${this.initrd} boot=live config noswap noprompt fetch=http://${Utils.address()}/live/filesystem.squashfs\n`
-        grubContent += `  linux (http) ${Utils.address()}/live/${this.vmlinuz}\n`
-        grubContent += `  initrd (http) ${Utils.address()}/live/${this.initrd}\n`
-        // grubContent += `  append boot=live config noswap noprompt fetch=http://${Utils.address()}/live/filesystem.squashfs\n`
-
-        grubContent += `}\n`
-        let grubFile = `${this.pxeRoot}grub/grub.cfg`
-        fs.writeFileSync(grubFile, grubContent)
-
-    }
-
-
-    /**
-     * 
-     */
-    configurePxelinux() {
-        let content = ``
-        content += `# eggs: pxelinux.cfg/default\n`
-        content += `# search path for the c32 support libraries (libcom32, libutil etc.)\n`
-        content += `path\n`
-        content += `include isolinux.theme.cfg\n`
-        content += `UI vesamenu.c32\n`
-        content += `\n`
-        content += `menu title Penguin's eggs - Perri's brewery edition - ${Utils.address()}\n`
-        content += `PROMPT 0\n`
-        content += `TIMEOUT 0\n`
-        content += `\n`
-
-        content += `LABEL http\n`
-        content += `MENU LABEL ${this.bootLabel}\n`
-        content += `MENU DEFAULT\n`
-        content += `KERNEL http://${Utils.address()}/live/${this.vmlinuz}\n`
-        content += `APPEND initrd=http://${Utils.address()}/live/${this.initrd} boot=live config noswap noprompt fetch=http://${Utils.address()}/live/filesystem.squashfs\n`
-        content += `SYSAPPEND 3\n`
-        content += `\n`
-
-        if (this.isos.length > 0) {
-            content += `MENU SEPARATOR\n`
-            for (const iso of this.isos) {
-                content += `\n`
-                content += `LABEL isos\n`
-                content += `MENU LABEL memdisk ${iso}\n`
-                content += `KERNEL memdisk\n`
-                content += `APPEND iso initrd=http://${Utils.address()}/${iso}\n`
-            }
-        }
-        let file = `${this.pxeRoot}/pxelinux.cfg/default`
-        fs.writeFileSync(file, content)
-    }
-
-    /**
      * start http server for images
      * 
      */
@@ -370,5 +380,18 @@ export default class Pxe {
             file.serve(req, res)
         }).listen(port)
     }
-}
 
+   /**
+    * 
+    * @param cmd 
+    */
+         async tryCatch(cmd = '') {
+            try {
+                await exec(cmd, this.echo)
+            } catch (error) {
+                console.log(`Error: ${error}`)
+                await Utils.pressKeyToExit(cmd)
+            }
+        }
+    
+}

--- a/src/classes/pxe.ts
+++ b/src/classes/pxe.ts
@@ -110,8 +110,8 @@ export default class Pxe {
         await this.tryCatch(`mkdir ${this.pxeRoot} -p`)
 
         // link boot, efi, isolinuxm live and .disk
-        await this.tryCatch(`ln -s ${this.isoRoot}boot ${this.pxeRoot}/boot`)
-        await this.tryCatch(`ln -s ${this.isoRoot}efi ${this.pxeRoot}/efi`)
+        // await this.tryCatch(`ln -s ${this.isoRoot}boot ${this.pxeRoot}/boot`)
+        // await this.tryCatch(`ln -s ${this.isoRoot}efi ${this.pxeRoot}/efi`)
         await this.tryCatch(`ln -s ${this.isoRoot}isolinux ${this.pxeRoot}/isolinux`)
         await this.tryCatch(`ln -s ${this.isoRoot}live ${this.pxeRoot}/live`)
         await this.tryCatch(`ln -s ${this.isoRoot}.disk ${this.pxeRoot}/.disk`)

--- a/src/commands/cuckoo.ts
+++ b/src/commands/cuckoo.ts
@@ -25,7 +25,7 @@ export default class Cuckoo extends Command {
   static description = 'cuckoo start a PXE boot server serving the live image'
 
   static flags = {
-    full: Flags.boolean({ char: 'f' }),
+    real: Flags.boolean({ char: 'r' , description: 'start a real dhcp server' }),
     help: Flags.help({ char: 'h' }),
     verbose: Flags.boolean({ char: 'v', description: 'verbose' })
   }
@@ -39,7 +39,7 @@ export default class Cuckoo extends Command {
     let verbose = flags.verbose
     const echo = Utils.setEcho(verbose)
 
-    let full = flags.full
+    let real = flags.real
 
     const distro = new Distro()
     if (distro.familyId === 'debian') {
@@ -59,7 +59,7 @@ export default class Cuckoo extends Command {
         const pxe = new Pxe()
         await pxe.fertilization()
         await pxe.structure()
-        await pxe.dnsMasq(full)
+        await pxe.dnsMasq(real)
         await pxe.httpStart()
 
         console.log(`Serving PXE boot, read more at: http://${Utils.address()}`)

--- a/src/commands/cuckoo.ts
+++ b/src/commands/cuckoo.ts
@@ -58,8 +58,9 @@ export default class Cuckoo extends Command {
         }
         const pxe = new Pxe()
         await pxe.fertilization()
-        await pxe.structure()
-        await pxe.dnsMasq(real)
+        await pxe.build()
+        let dnsmasq = true
+        await pxe.dhcp(real, dnsmasq)
         await pxe.httpStart()
 
         console.log(`Serving PXE boot, read more at: http://${Utils.address()}`)


### PR DESCRIPTION
```cuckoo``` since version **eggs-9.2.5**, 16 on **september 2022**, is capable to boot BIOS and UEFI machines, however due to a bug in slim package, using sudo eggs cuckoo in dhcp-proxy version will not get UEFI machines to boot. Instead, use: sudo eggs cuckoo --real. 

__Warning__: using ``eggs cuckpp --real`` adds additional dhcp to the network, this may lead to problems or be prohibited by your organization,
