### PR TITLE
Devel

### DIFF
--- a/addons/templates/grub.template
+++ b/addons/templates/grub.template
@@ -4,7 +4,6 @@
 
 # ieee1275_fb.mod vbe.mod vga.mod not found
 
-#if loadfont $prefix/unifont.pf2; then
 if loadfont $prefix/font.pf2 ; then
   set gfxmode=1024x768
   insmod efi_gop

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,8 @@ Versions are listed on reverse order, the first is the last one. Old versions ar
 
 **Note:** test packages with the final letter: -a, -b, -c etcetera are uploaded to the DEBS/testing folder of sourceforge.
 
+### eggs-9.4.16
+* added custom calamares-module ;
 
 ### eggs-9.4.15
 * egg of [blendOS](https://blendos.co/) now install and can re-produce! Until now I used version [23.04-1](https://sourceforge.net/projects/blendos/files/23.04-1/). You can find samples on [sample](https://sourceforge.net/projects/penguins-eggs/files/ISOS/blendos/).

--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@ Versions are listed on reverse order, the first is the last one. Old versions ar
 
 ### eggs-9.4.16
 * added custom calamares-module ;
+* `eggs install -un` krill the CLI installer now work in arch too.
 
 ### eggs-9.4.15
 * egg of [blendOS](https://blendos.co/) now install and can re-produce! Until now I used version [23.04-1](https://sourceforge.net/projects/blendos/files/23.04-1/). You can find samples on [sample](https://sourceforge.net/projects/penguins-eggs/files/ISOS/blendos/).

--- a/changelog.md
+++ b/changelog.md
@@ -20,8 +20,9 @@ Versions are listed on reverse order, the first is the last one. Old versions ar
 **Note:** test packages with the final letter: -a, -b, -c etcetera are uploaded to the DEBS/testing folder of sourceforge.
 
 ### eggs-9.4.16
-* added custom calamares-module ;
-* `eggs install -un` krill the CLI installer now work in arch too.
+Almost no differences, except the work to add custom-calamares-modules to let possible configure easily custom installation with calamares or krill;
+* Note: actually krill `eggs install -un` - the CLI installer - can work on Arch too;
+* Some fixex.
 
 ### eggs-9.4.15
 * egg of [blendOS](https://blendos.co/) now install and can re-produce! Until now I used version [23.04-1](https://sourceforge.net/projects/blendos/files/23.04-1/). You can find samples on [sample](https://sourceforge.net/projects/penguins-eggs/files/ISOS/blendos/).

--- a/sourceforge/files/DEBS/testing/README.md
+++ b/sourceforge/files/DEBS/testing/README.md
@@ -17,10 +17,9 @@ Penguins-eggs
 
 * added in penguins-wardrobe theme bliss; to use this theme `git clone https://github.com/pieroproietti/penguins-wardrobe`, `cd penguins-wardrobe`, `git checkout devel`, then `sudo eggs produce --theme ./penguins-wardrobe/theme/bliss`
 
-```
-NOTE:   this version are just to test [bliss theme](https://github.com/pieroproietti/penguins-wardrobe/tree/main/themes/bliss#readme) usage in penguins-wardrobe, except for this any 
-        changes is included. 
-```
+
+**NOTE**: this version is just to test [bliss theme](https://github.com/pieroproietti/penguins-wardrobe/tree/main/themes/bliss#readme) usage in penguins-wardrobe, except for this any changes is included. 
+
 
 # Penguins' eggs Debian TESTING packages
 

--- a/sourceforge/files/DEBS/testing/README.md
+++ b/sourceforge/files/DEBS/testing/README.md
@@ -13,9 +13,9 @@ Penguins-eggs
 
 # development
 
-## changelog eggs-v9.4.6 vs eggs-v9.4.5
-* releasing v9.4.5
+## changelog eggs-v9.4.16 vs v9.4.15
 
+* added in penguins-wardrobe theme bliss; to use this theme `git clone https://github.com/pieroproietti/penguins-wardrobe`, `cd penguins-wardrobe`, `git checkout devel`, then `sudo eggs produce --theme ./penguins-wardrobe/theme/bliss`
 
 
 # Penguins' eggs Debian TESTING packages

--- a/sourceforge/files/DEBS/testing/README.md
+++ b/sourceforge/files/DEBS/testing/README.md
@@ -18,7 +18,7 @@ Penguins-eggs
 * added in penguins-wardrobe theme bliss; to use this theme `git clone https://github.com/pieroproietti/penguins-wardrobe`, `cd penguins-wardrobe`, `git checkout devel`, then `sudo eggs produce --theme ./penguins-wardrobe/theme/bliss`
 
 ```
-NOTE:   this version are just to test bliss theme usage in penguins-wardrobe, except for this any 
+NOTE:   this version are just to test [bliss theme](https://github.com/pieroproietti/penguins-wardrobe/tree/main/themes/bliss#readme) usage in penguins-wardrobe, except for this any 
         changes is included. 
 ```
 

--- a/sourceforge/files/DEBS/testing/README.md
+++ b/sourceforge/files/DEBS/testing/README.md
@@ -13,10 +13,14 @@ Penguins-eggs
 
 # development
 
-## changelog eggs-v9.4.16 vs v9.4.15
+## changelog eggs-v9.4.16
 
 * added in penguins-wardrobe theme bliss; to use this theme `git clone https://github.com/pieroproietti/penguins-wardrobe`, `cd penguins-wardrobe`, `git checkout devel`, then `sudo eggs produce --theme ./penguins-wardrobe/theme/bliss`
 
+```
+NOTE:   this version are just to test bliss theme usage in penguins-wardrobe, except for this any 
+        changes is included. 
+```
 
 # Penguins' eggs Debian TESTING packages
 

--- a/src/classes/ccm.ts
+++ b/src/classes/ccm.ts
@@ -22,3 +22,7 @@ export function ccm() : string [] {
    }
    return ccm
 }
+
+/**
+ * 
+ */

--- a/src/classes/ccm.ts
+++ b/src/classes/ccm.ts
@@ -1,0 +1,24 @@
+
+/**
+ * 
+ */
+import {ISettings} from '../interfaces/i-settings'
+import fs from 'fs'
+import yaml from 'js-yaml'
+
+/**
+ * custom calamares modules
+ */
+export function ccm() : string [] {
+   const ccm: string [] = []
+   const settingsVar: string = fs.readFileSync('/etc/calamares/settings.conf', 'utf8')
+   const settingsYaml = yaml.load(settingsVar) as ISettings
+   const execSequence = settingsYaml.sequence[1]
+   const steps = execSequence.exec
+   for (const step of steps) {
+      if (step.includes('ccm-')) {
+         ccm.push(step)
+      }
+   }
+   return ccm
+}

--- a/src/classes/incubation/distros/buster.ts
+++ b/src/classes/incubation/distros/buster.ts
@@ -12,6 +12,8 @@ import shx from 'shelljs'
 import yaml from 'js-yaml'
 import path from 'node:path'
 
+import {ccm} from '../../ccm'
+
 import {IInstaller, IRemix, IDistro} from '../../../interfaces/index'
 
 import Fisherman from '../fisherman'
@@ -91,6 +93,16 @@ export class Buster {
     await fisherman.moduleRemoveuser(this.user_opt)
     await fisherman.buildCalamaresModule('sources-yolk-undo', false)
     await fisherman.buildCalamaresModule('cleanup', true)
+
+    /**
+     * custom calamares modules
+     */
+    const cm = ccm()
+    if (cm.length > 0) {
+      for (const step of cm) {
+        await fisherman.buildCalamaresModule(step, true, this.theme)
+      }
+    }
     await fisherman.buildModule('umount')
     await fisherman.moduleFinished()
   }

--- a/src/classes/incubation/distros/buster.ts
+++ b/src/classes/incubation/distros/buster.ts
@@ -91,10 +91,6 @@ export class Buster {
     await fisherman.moduleRemoveuser(this.user_opt)
     await fisherman.buildCalamaresModule('sources-yolk-undo', false)
     await fisherman.buildCalamaresModule('cleanup', true)
-    // bliss patch
-    if (this.theme.includes('bliss')) {
-      await fisherman.buildCalamaresModule('blissos', true, this.theme)
-    }
     await fisherman.buildModule('umount')
     await fisherman.moduleFinished()
   }

--- a/src/classes/incubation/distros/buster.ts
+++ b/src/classes/incubation/distros/buster.ts
@@ -97,12 +97,13 @@ export class Buster {
     /**
      * custom calamares modules
      */
-    const cm = ccm()
-    if (cm.length > 0) {
-      for (const step of cm) {
+    const steps = ccm()
+    if (steps.length > 0) {
+      for (const step of steps) {
         await fisherman.buildCalamaresModule(step, true, this.theme)
       }
     }
+
     await fisherman.buildModule('umount')
     await fisherman.moduleFinished()
   }

--- a/src/classes/incubation/distros/focal.ts
+++ b/src/classes/incubation/distros/focal.ts
@@ -15,6 +15,8 @@ import Fisherman from '../fisherman'
 import {exec} from '../../../lib/utils'
 import {throws} from 'node:assert'
 
+import {ccm} from '../../ccm'
+
 interface IReplaces {
   search: string
   replace: string
@@ -93,11 +95,14 @@ export class Focal {
     await fisherman.buildCalamaresModule('sources-yolk-undo', false)
     await fisherman.buildCalamaresModule('cleanup', true)
 
-    // bliss calamares-modules
-    if (this.theme.includes('bliss')) {
-      await fisherman.buildCalamaresModule('bliss-install', true, this.theme)
-      await fisherman.buildCalamaresModule('bliss-data-img', true, this.theme)
-      await fisherman.buildCalamaresModule('bliss-bootloader', true, this.theme)
+    /**
+     * custom calamares modules
+     */
+    const cm = ccm()
+    if (cm.length > 0) {
+      for (const step of cm) {
+        await fisherman.buildCalamaresModule(step, true, this.theme)
+      }
     }
 
     await fisherman.buildModule('umount')

--- a/src/classes/incubation/distros/focal.ts
+++ b/src/classes/incubation/distros/focal.ts
@@ -93,10 +93,13 @@ export class Focal {
     await fisherman.buildCalamaresModule('sources-yolk-undo', false)
     await fisherman.buildCalamaresModule('cleanup', true)
 
-    // bliss patch
+    // bliss calamares-modules
     if (this.theme.includes('bliss')) {
-      await fisherman.buildCalamaresModule('blissos', true, this.theme)
+      await fisherman.buildCalamaresModule('bliss-install', true, this.theme)
+      await fisherman.buildCalamaresModule('bliss-data-img', true, this.theme)
+      await fisherman.buildCalamaresModule('bliss-bootloader', true, this.theme)
     }
+
     await fisherman.buildModule('umount')
     await fisherman.buildModule('finished')
   }

--- a/src/classes/incubation/distros/focal.ts
+++ b/src/classes/incubation/distros/focal.ts
@@ -98,9 +98,9 @@ export class Focal {
     /**
      * custom calamares modules
      */
-    const cm = ccm()
-    if (cm.length > 0) {
-      for (const step of cm) {
+    const steps = ccm()
+    if (steps.length > 0) {
+      for (const step of steps) {
         await fisherman.buildCalamaresModule(step, true, this.theme)
       }
     }

--- a/src/classes/ovary.ts
+++ b/src/classes/ovary.ts
@@ -1542,7 +1542,9 @@ export default class Ovary {
 
     // if this doesn't work try another font from the same place (grub's default, unicode.pf2, is much larger)
     // Either of these will work, and they look the same to me. Unicode seems to work with qemu. -fsr
-    if (fs.existsSync('/usr/share/grub/unicode.pf2')) {
+    if (fs.existsSync('/usr/share/grub/font.pf2')) {
+      await exec(`cp /usr/share/grub/font.pf2 ${efiWorkDir}/boot/grub/font.pf2`, this.echo)
+    } else if (fs.existsSync('/usr/share/grub/unicode.pf2')) {
       await exec(`cp /usr/share/grub/unicode.pf2 ${efiWorkDir}/boot/grub/font.pf2`, this.echo)
     } else if (fs.existsSync('/usr/share/grub/ascii.pf2')) {
       await exec(`cp /usr/share/grub/ascii.pf2 ${efiWorkDir}/boot/grub/font.pf2`, this.echo)

--- a/src/classes/ovary.ts
+++ b/src/classes/ovary.ts
@@ -1172,6 +1172,7 @@ export default class Ovary {
       cmds.push(await rexec(`chroot ${this.settings.work_dir.merged} usermod -aG sudo ${this.settings.config.user_opt}`, this.verbose))
     } else if (this.familyId === 'archlinux') {
       cmds.push(await rexec(`chroot ${this.settings.work_dir.merged} gpasswd -a ${this.settings.config.user_opt} wheel`, this.verbose))
+      
       // check or create group: autologin
       cmds.push(await rexec(`chroot ${this.settings.work_dir.merged} getent group autologin || groupadd autologin`, this.verbose))
       cmds.push(await rexec(`chroot ${this.settings.work_dir.merged} gpasswd -a ${this.settings.config.user_opt} autologin`, this.verbose))

--- a/src/commands/produce.ts
+++ b/src/commands/produce.ts
@@ -130,7 +130,7 @@ export default class Produce extends Command {
           process.exit()
         }
       }
-      console.log(`theme_ ${theme}`)
+      console.log(`theme: ${theme}`)
 
       const i = await Config.thatWeNeed(nointeractive, verbose, cryptedclone)
       if ((i.needApt || i.configurationInstall || i.configurationRefresh || i.distroTemplate) && (await Utils.customConfirm('Select yes to continue...'))) {

--- a/src/interfaces/i-settings.ts
+++ b/src/interfaces/i-settings.ts
@@ -1,10 +1,31 @@
+/**
+ * settings calamares
+ * 
+ */
+
+interface Iinstance {
+  id: string      // 'before_bootloader_mkdirs'
+  moduce: string  // 'contextualprocess',
+  config: string  // 'before_bootloader_mkdirs_context.conf'
+}
+
+/**
+ * 
+ */
 export interface ISettings {
-  'modules-search': string[]
-  sequence: {
-    show: string[]
-    exec: string[]
-  }
-  branding: string
-  'prompt-install': boolean
-  'dont-chroot': boolean
+  "modules-search": string[]
+  "instances": [
+    instance: Iinstance
+  ]
+  "sequence": [
+      { show: string[]},
+      { exec: string[]},
+      { show: string[]}
+    ]
+  "branding": string,
+  "prompt-install": boolean
+  "dont-chroot": boolean
+  "oem-setup": boolean
+  "disable-cancel": boolean
+  "disable-cancel-during-exec": boolean
 }

--- a/src/krill/krill-sequence.tsx
+++ b/src/krill/krill-sequence.tsx
@@ -65,6 +65,7 @@ import { installer } from '../classes/incubation/installer'
 import Xdg from '../classes/xdg';
 import Distro from '../classes/distro'
 
+
 import { IInstaller, IDevices, IDevice } from '../interfaces/index'
 import { ICalamaresModule, ILocation, IKeyboard, IPartitions, IUsers } from '../interfaces/i-krill'
 import { exec } from '../lib/utils'
@@ -107,6 +108,9 @@ import umount from './modules/umount'
 import mkfs from './modules/mkfs'
 import hostname from './modules/hostname'
 import { ReadableByteStreamController } from 'stream/web';
+import { createCompilerHost } from 'typescript';
+
+import {ccm} from '../classes/ccm'
 
 /**
  * hatching: installazione o cova!!!
@@ -623,11 +627,26 @@ export default class Sequence {
             await Utils.pressKeyToExit(JSON.stringify(error))
          }
 
-
          /**
-          * TO DO: here we need to check theme and if 
-          *        theme=bliss, then call custom modules
+          * custom calamares modules
           */
+         const cm = ccm()
+         if (cm.length > 0) {
+            for (const step of cm) {
+               if (this.distro.familyId === 'debian') {
+                  message = `running ${step}`
+                  percent = 0.97
+                  try {
+                     await redraw(<Install message={message} percent={percent} />)
+                     await this.execCalamaresModule(step)
+                  } catch (error) {
+                     await Utils.pressKeyToExit(JSON.stringify(error))
+                  }
+               }
+            }
+         }
+
+
 
          // umount
          message = "umount"
@@ -716,3 +735,4 @@ function sleep(ms = 0) {
       setTimeout(resolve, ms);
    });
 }
+

--- a/src/krill/krill-sequence.tsx
+++ b/src/krill/krill-sequence.tsx
@@ -259,6 +259,12 @@ export default class Sequence {
     */
    async start(domain = 'local', unattended = false, nointeractive = false, halt = false, verbose = false) {
 
+      /**
+       * To let krill to work with Arch
+       */
+      if (this.distro.familyId=== 'archlinux') {
+         await exec(`sudo ln -s /run/archiso/bootmnt/live/ /live`)
+      }
       this.unattended = unattended
       this.nointeractive = nointeractive
       this.halt = halt

--- a/src/krill/krill-sequence.tsx
+++ b/src/krill/krill-sequence.tsx
@@ -42,6 +42,7 @@
  *  - initramfs:     initramfs
  *  - removeuser:    removeuser
  *  - sources-yolk-undo: execCalamaresModule('sources-yolk-undo')
+ *  - bliss clustom modules
  *  - umount:     umountVfs, this.umountFs
  */
 
@@ -621,6 +622,12 @@ export default class Sequence {
          } catch (error) {
             await Utils.pressKeyToExit(JSON.stringify(error))
          }
+
+
+         /**
+          * TO DO: here we need to check theme and if 
+          *        theme=bliss, then call custom modules
+          */
 
          // umount
          message = "umount"

--- a/src/krill/krill-sequence.tsx
+++ b/src/krill/krill-sequence.tsx
@@ -646,8 +646,6 @@ export default class Sequence {
             }
          }
 
-
-
          // umount
          message = "umount"
          percent = 0.98

--- a/src/krill/krill-sequence.tsx
+++ b/src/krill/krill-sequence.tsx
@@ -260,11 +260,12 @@ export default class Sequence {
    async start(domain = 'local', unattended = false, nointeractive = false, halt = false, verbose = false) {
 
       /**
-       * To let krill to work with Arch
+       * To let krill to work with Arch we need:
        */
       if (this.distro.familyId=== 'archlinux') {
          await exec(`sudo ln -s /run/archiso/bootmnt/live/ /live`)
       }
+
       this.unattended = unattended
       this.nointeractive = nointeractive
       this.halt = halt
@@ -526,6 +527,13 @@ export default class Sequence {
                   percent = 0.78
                   if (this.users.autologin) {
                      await Xdg.autologin(await Utils.getPrimaryUser(), this.users.name, this.installTarget)
+                     /**
+                      * on Arch we need gruup autologin
+                      */
+                     if (this.distro.familyId=== 'archlinux') {
+                        await exec(`chroot ${this.installTarget} getent group autologin || groupadd autologin`)
+                        await exec(`chroot ${this.installTarget} gpasswd -a ${this.users.name}`)
+                     }
                   }
                   await redraw(<Install message={message} percent={percent} />)
                } catch (error) {

--- a/src/krill/krill-sequence.tsx
+++ b/src/krill/krill-sequence.tsx
@@ -527,13 +527,6 @@ export default class Sequence {
                   percent = 0.78
                   if (this.users.autologin) {
                      await Xdg.autologin(await Utils.getPrimaryUser(), this.users.name, this.installTarget)
-                     /**
-                      * on Arch we need gruup autologin
-                      */
-                     if (this.distro.familyId=== 'archlinux') {
-                        await exec(`chroot ${this.installTarget} getent group autologin || groupadd autologin`)
-                        await exec(`chroot ${this.installTarget} gpasswd -a ${this.users.name}`)
-                     }
                   }
                   await redraw(<Install message={message} percent={percent} />)
                } catch (error) {

--- a/src/krill/modules/add-user.ts
+++ b/src/krill/modules/add-user.ts
@@ -4,7 +4,7 @@
 
 import Sequence from '../krill-sequence'
 import Utils from '../../classes/utils'
-import {exec} from '../../lib/utils'
+import { exec } from '../../lib/utils'
 
 /**
  *
@@ -32,14 +32,15 @@ export default async function addUser(this: Sequence, name = 'live', password = 
   cmd = `chroot ${this.installTarget} usermod -aG sudo ${name} ${this.toNull}`
   if (this.distro.familyId === 'archlinux') {
     cmd = `chroot ${this.installTarget} usermod -aG wheel ${name}`
-    // check or create group: autologin
-    await exec(`chroot ${this.installTarget} getent group autologin || groupadd autologin`)
-    await exec(`chroot ${this.installTarget} gpasswd -a ${this.settings.config.user_opt} autologin`)
-
   }
 
   try {
     await exec(cmd, this.echo)
+    // check or create group: autologin
+    if (this.distro.familyId === 'archlinux') {
+      await exec(`chroot ${this.installTarget} getent group autologin || groupadd autologin`)
+      await exec(`chroot ${this.installTarget} gpasswd -a ${this.settings.config.user_opt} autologin`)
+    }
   } catch {
     await Utils.pressKeyToExit(cmd)
   }

--- a/src/krill/modules/add-user.ts
+++ b/src/krill/modules/add-user.ts
@@ -26,13 +26,16 @@ export default async function addUser(this: Sequence, name = 'live', password = 
   await exec(cmd, this.echo)
 
   cmd = `echo ${name}:${password} | chroot ${this.installTarget} chpasswd ${this.toNull}`
-  //  echo ${name}:${password} | chroot ${this.installTarget} chpasswd ${this.toNull}
   await exec(cmd, this.echo)
 
   // Debian
   cmd = `chroot ${this.installTarget} usermod -aG sudo ${name} ${this.toNull}`
   if (this.distro.familyId === 'archlinux') {
     cmd = `chroot ${this.installTarget} usermod -aG wheel ${name}`
+    // check or create group: autologin
+    await exec(`chroot ${this.installTarget} getent group autologin || groupadd autologin`)
+    await exec(`chroot ${this.installTarget} gpasswd -a ${this.settings.config.user_opt} autologin`)
+
   }
 
   try {

--- a/src/krill/modules/mount-fs.ts
+++ b/src/krill/modules/mount-fs.ts
@@ -8,7 +8,6 @@
  */
 
 import Sequence from '../krill-sequence'
-import Utils from '../../classes/utils'
 import {exec} from '../../lib/utils'
 import fs from 'fs'
 

--- a/testing/settings.ts
+++ b/testing/settings.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/pnpx ts-node
+/**
+ * run with: pnpx ts-node
+ * #!/usr/bin/pnpx ts-node
+ */
+
+interface Iinstance {
+  id: string      // 'before_bootloader_mkdirs'
+  moduce: string  // 'contextualprocess',
+  config: string  // 'before_bootloader_mkdirs_context.conf'
+}
+
+interface ISettings {
+  "modules-search": string[]
+  "instances": [
+    instance: Iinstance
+  ]
+  "sequence": [
+    { show: string[] },
+    { exec: string[] },
+    { show: string[] },
+  ]
+  "branding": string,
+  "prompt-install": boolean
+  "dont-chroot": boolean
+  "oem-setup": boolean
+  "disable-cancel": boolean
+  "disable-cancel-during-exec": boolean
+}
+
+
+
+import Utils from '../src/classes/utils'
+import fs from 'fs'
+import yaml from 'js-yaml'
+
+Utils.titles('settings')
+
+
+
+main()
+
+async function main() {
+  const settingsVar: string = fs.readFileSync('/etc/calamares/settings.conf', 'utf8')
+  const settingsYaml = yaml.load(settingsVar) as ISettings
+
+  // console.log()
+  // console.log(settingsYaml.sequence[0])
+
+  console.log()
+  const sequence = settingsYaml.sequence[1]
+  console.log(sequence)
+
+  // console.log()
+  // console.log(settingsYaml.sequence[2])
+}
+
+
+/*
+const p = {
+  'modules-search': ['local'],
+  instances: [
+    {
+      id: 'before_bootloader_mkdirs',
+      module: 'contextualprocess',
+      config: 'before_bootloader_mkdirs_context.conf'
+    },
+    {
+      id: 'before_bootloader',
+      module: 'contextualprocess',
+      config: 'before_bootloader_context.conf'
+    },
+    {
+      id: 'after_bootloader',
+      module: 'contextualprocess',
+      config: 'after_bootloader_context.conf'
+    },
+    {
+      id: 'logs',
+      module: 'shellprocess',
+      config: 'shellprocess_logs.conf'
+    },
+    {
+      id: 'bug-LP#1829805',
+      module: 'shellprocess',
+      config: 'shellprocess_bug-LP#1829805.conf'
+    },
+    {
+      id: 'add386arch',
+      module: 'shellprocess',
+      config: 'shellprocess_add386arch.conf'
+    }
+  ],
+  sequence: [{ show: [Array] }, { exec: [Array] }, { show: [Array] }],
+  branding: 'sample',
+  'prompt-install': true,
+  'dont-chroot': false,
+  'oem-setup': false,
+  'disable-cancel': false,
+  'disable-cancel-during-exec': false
+}
+*/

--- a/testing/settings.ts
+++ b/testing/settings.ts
@@ -4,32 +4,7 @@
  * #!/usr/bin/pnpx ts-node
  */
 
-interface Iinstance {
-  id: string      // 'before_bootloader_mkdirs'
-  moduce: string  // 'contextualprocess',
-  config: string  // 'before_bootloader_mkdirs_context.conf'
-}
-
-interface ISettings {
-  "modules-search": string[]
-  "instances": [
-    instance: Iinstance
-  ]
-  "sequence": [
-    { show: string[] },
-    { exec: string[] },
-    { show: string[] },
-  ]
-  "branding": string,
-  "prompt-install": boolean
-  "dont-chroot": boolean
-  "oem-setup": boolean
-  "disable-cancel": boolean
-  "disable-cancel-during-exec": boolean
-}
-
-
-
+import {ISettings} from '../src/interfaces/i-settings'
 import Utils from '../src/classes/utils'
 import fs from 'fs'
 import yaml from 'js-yaml'
@@ -45,58 +20,19 @@ async function main() {
   const settingsYaml = yaml.load(settingsVar) as ISettings
 
   // console.log()
-  // console.log(settingsYaml.sequence[0])
+  // console.log(settingsYaml.sequence)
 
   console.log()
-  const sequence = settingsYaml.sequence[1]
-  console.log(sequence)
+
+  const execSequence = settingsYaml.sequence[1]
+  console.log(execSequence.exec)
+  const steps = execSequence.exec
+  for (const step of steps){
+    if (step.includes('bliss-')) {
+      console.log(`- ${step}`)
+    }
+  }
 
   // console.log()
   // console.log(settingsYaml.sequence[2])
 }
-
-
-/*
-const p = {
-  'modules-search': ['local'],
-  instances: [
-    {
-      id: 'before_bootloader_mkdirs',
-      module: 'contextualprocess',
-      config: 'before_bootloader_mkdirs_context.conf'
-    },
-    {
-      id: 'before_bootloader',
-      module: 'contextualprocess',
-      config: 'before_bootloader_context.conf'
-    },
-    {
-      id: 'after_bootloader',
-      module: 'contextualprocess',
-      config: 'after_bootloader_context.conf'
-    },
-    {
-      id: 'logs',
-      module: 'shellprocess',
-      config: 'shellprocess_logs.conf'
-    },
-    {
-      id: 'bug-LP#1829805',
-      module: 'shellprocess',
-      config: 'shellprocess_bug-LP#1829805.conf'
-    },
-    {
-      id: 'add386arch',
-      module: 'shellprocess',
-      config: 'shellprocess_add386arch.conf'
-    }
-  ],
-  sequence: [{ show: [Array] }, { exec: [Array] }, { show: [Array] }],
-  branding: 'sample',
-  'prompt-install': true,
-  'dont-chroot': false,
-  'oem-setup': false,
-  'disable-cancel': false,
-  'disable-cancel-during-exec': false
-}
-*/


### PR DESCRIPTION
# eggs-9.4.16

Almost no differences, except the work to add custom-calamares-modules to let possible configure easily custom installation with calamares or krill;
* Note: actually krill eggs install -un - the CLI installer - can work on Arch too;
* Some fixes.
