### PR TITLE
Calamares 3.3 for Arch

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,7 @@
 
 * calamares su blendOS non funziona su BIOS ed in verità manco su EFI, qua il problema dovrebbe essere la versione 3.3 di calamares;
 ```
+
 * su blendos il `/proc/cmdline` punta a `/vmlinuz-linux-zen` mentre il vero path è `/boot/vmlinuz-linux-zen` così come `/boot/initramfs-linux.img`;
 
 ``` 

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,12 @@ Versions are listed on reverse order, the first is the last one. Old versions ar
 
 **Note:** test packages with the final letter: -a, -b, -c etcetera are uploaded to the DEBS/testing folder of sourceforge.
 
+
+### eggs-9.5.4
+* adding `eggs sudo tools ppa` for Arch, here we set repository `chaotic-aur`;
+* removed `rolling-` on the default name for Arch, alle the Arch versions are rolling;
+* passed to calamares 3.3 for Arch;
+
 ### eggs-9.5.3
 * solved issues [Krill installer fails on actual hardware #245](https://github.com/pieroproietti/penguins-eggs/issues/245);
 

--- a/conf/distros/rolling/README.md
+++ b/conf/distros/rolling/README.md
@@ -1,3 +1,0 @@
-# Archlinux
-
-do to

--- a/conf/distros/rolling/calamares/modules/bootloader.yml
+++ b/conf/distros/rolling/calamares/modules/bootloader.yml
@@ -1,0 +1,75 @@
+# calamares 3.3
+# arch
+---
+# A variable from global storage which overrides the value of efiBootLoader
+#efiBootLoaderVar: "packagechooser_bootloader"
+
+# Define which bootloader you want to use for EFI installations
+# Possible options are 'grub', 'sb-shim', 'refind` and 'systemd-boot'.
+efiBootLoader: "grub"
+
+# systemd-boot configuration files settings
+
+# kernelSearchPath is the path relative to the root of the install to search for kernels
+# A kernel is identified by finding files which match regular expression, kernelPattern
+kernelSearchPath: "/usr/lib/modules"
+kernelPattern: "^vmlinuz.*"
+
+# loaderEntries is an array of options to add to loader.conf for systemd-boot
+# please note that the "default" option is added programmatically
+loaderEntries:
+  - "timeout 5"
+  - "console-mode keep"
+
+# systemd-boot and refind support custom kernel params
+kernelParams: [ "quiet" ]
+
+# A list of kernel names that refind should accept as kernels
+#refindKernelList: [ "linux","linux-lts","linux-zen","linux-hardened" ]
+
+# GRUB 2 binary names and boot directory
+# Some distributions (e.g. Fedora) use grub2-* (resp. /boot/grub2/) names.
+# These names are also used when using sb-shim, since that needs some
+# GRUB functionality (notably grub-probe) to work. As needed, you may use
+# complete paths like `/usr/bin/efibootmgr` for the executables.
+#
+grubInstall: "grub-install"
+grubMkconfig: "grub-mkconfig"
+grubCfg: "/boot/grub/grub.cfg"
+grubProbe: "grub-probe"
+efiBootMgr: "efibootmgr"
+
+# Optionally set the bootloader ID to use for EFI. This is passed to
+# grub-install --bootloader-id.
+#
+# If not set here, the value from bootloaderEntryName from branding.desc
+# is used, with problematic characters (space and slash) replaced.
+#
+# The ID is also used as a directory name within the EFI environment,
+# and the bootloader is copied from /boot/efi/EFI/<dirname>/ . When
+# setting the option here, keep in mind that the name is sanitized
+# (problematic characters, see above, are replaced).
+#
+# There are some special words possible at the end of *efiBootloaderId*:
+#   ${SERIAL} can be used to obtain a uniquely-numbered suffix
+#       that is added to the Id (yielding, e.g., `dirname1` or `dirname72`)
+#   ${RANDOM} can be used to obtain a unique 4-digit hex suffix
+#   ${PHRASE} can be used to obtain a unique 1-to-3-word suffix
+#       from a dictionary of space-themed words
+# These words must be at the **end** of the *efiBootloaderId* value.
+# There must also be at most one of them. If there is none, no suffix-
+# processing is done and the *efiBootloaderId* is used unchanged.
+#
+# NOTE: Debian derivatives that use the unmodified Debian GRUB EFI
+#       packages may need to set this to "debian" because that is
+#       hard-coded in `grubx64.efi`.
+#
+# efiBootloaderId: "dirname"
+
+# Optionally install a copy of the GRUB EFI bootloader as the EFI
+# fallback loader (either bootia32.efi or bootx64.efi depending on
+# the system). This may be needed on certain systems (Intel DH87MC
+# seems to be the only one). If you set this to false, take care
+# to add another module to optionally install the fallback on those
+# boards that need it.
+installEFIFallback: true

--- a/conf/distros/rolling/calamares/modules/finished.yml
+++ b/conf/distros/rolling/calamares/modules/finished.yml
@@ -1,6 +1,46 @@
-# Debian Buster
-# finished
+# Calamares 3.3
+# Arch
 ---
-restartNowEnabled: true
-restartNowChecked: true
+# DEPRECATED
+#
+# The finished page can hold a "restart system now" checkbox.
+# If this is false, no checkbox is shown and the system is not restarted
+# when Calamares exits.
+# restartNowEnabled: true
+
+# DEPRECATED
+#
+# Initial state of the checkbox "restart now". Only relevant when the
+# checkbox is shown by restartNowEnabled.
+# restartNowChecked: false
+
+# Behavior of the "restart system now" button.
+#
+# There are four usable values:
+#   - never
+#       Does not show the button and does not restart.
+#       This matches the old behavior with restartNowEnabled=false.
+#   - user-unchecked
+#       Shows the button, defaults to unchecked, restarts if it is checked.
+#       This matches the old behavior with restartNowEnabled=true and restartNowChecked=false.
+#   - user-checked
+#       Shows the button, defaults to checked, restarts if it is checked.
+#       This matches the old behavior with restartNowEnabled=true and restartNowChecked=true.
+#   - always
+#       Shows the button, checked, but the user cannot change it.
+#       This is new behavior.
+#
+# The three combinations of legacy values are still supported.
+restartNowMode: user-unchecked
+
+# If the checkbox is shown, and the checkbox is checked, then when
+# Calamares exits from the finished-page it will run this command.
+# If not set, falls back to "shutdown -r now".
 restartNowCommand: {{restartNowCommand}}
+
+# When the last page is (successfully) reached, send a DBus notification
+# to the desktop that the installation is done. This works only if the
+# user as whom Calamares is run, can reach the regular desktop session bus.
+notifyOnFinished: false
+
+

--- a/conf/distros/rolling/calamares/modules/fstab.yml
+++ b/conf/distros/rolling/calamares/modules/fstab.yml
@@ -1,13 +1,31 @@
-# Debian Buster
-# fstab
+# calamares 3.3
+# Arch
 ---
-mountOptions:
-  default: defaults,noatime
-  btrfs: defaults,noatime,space_cache,autodefrag
-ssdExtraMountOptions:
-  ext4: discard
-  jfs: discard
-  xfs: discard
-  swap: discard
-  btrfs: discard,compress=lzo
-crypttabOptions: luks,keyscript=/bin/cat
+
+# Additional options added to each line in /etc/crypttab
+crypttabOptions: luks
+# For Debian and Debian-based distributions, change the above line to:
+# crypttabOptions: luks,keyscript=/bin/cat
+
+# Options for handling /tmp in /etc/fstab
+# Currently default (required) and ssd are supported
+# The corresponding string can contain the following variables:
+# tmpfs: true or tmpfs: false to either mount /tmp as tmpfs or not
+# options: "<mount options>"
+#
+# Example:
+#tmpOptions:
+#    default:
+#        tmpfs: false
+#        options: ""
+#    ssd:
+#        tmpfs: true
+#        options: "defaults,noatime,mode=1777"
+#
+tmpOptions:
+    default:
+        tmpfs: false
+        options: ""
+    ssd:
+        tmpfs: true
+        options: "defaults,noatime,mode=1777"

--- a/conf/distros/rolling/calamares/modules/locale.yml
+++ b/conf/distros/rolling/calamares/modules/locale.yml
@@ -1,5 +1,8 @@
+# Calamares 3.3.
+# Arch
+#
 ---
-# This settings are used to set your default system time zone.
+# These settings are used to set your default system time zone.
 # Time zones are usually located under /usr/share/zoneinfo and
 # provided by the 'tzdata' package of your Distribution.
 #
@@ -11,33 +14,58 @@
 # the locale page can be set through keys *region* and *zone*.
 # If either is not set, defaults to America/New_York.
 #
+# Note that useSystemTimezone and GeoIP settings can change the
+# starting time zone.
+#
 region:                     "Europe"
 zone:                       "Rome"
 
+# Instead of using *region* and *zone* specified above,
+# you can use the system's notion of the timezone, instead.
+# This can help if your system is automatically configured with
+# a sensible TZ rather than chasing a fixed default.
+#
+# The default is false.
+#
+# useSystemTimezone: true
+
+# Should changing the system location (e.g. clicking around on the timezone
+# map) immediately reflect the changed timezone in the live system?
+# By default, installers (with a target system) do, and setup (e.g. OEM
+# configuration) does not, but you can switch it on here (or off, if
+# you think it's annoying in the installer).
+#
+# Note that not all systems support live adjustment.
+#
+# adjustLiveTimezone:   true
 
 # System locales are detected in the following order:
 #
 #  - /usr/share/i18n/SUPPORTED
 #  - localeGenPath (defaults to /etc/locale.gen if not set)
-#  - 'locale -a' output
+#  - `locale -a` output
 #
-# Enable only when your Distribution is using an
+# Enable only when your Distribution is using a
 # custom path for locale.gen
 #
-#localeGenPath:             "PATH_TO/locale.gen"
+#localeGenPath:             "/etc/locale.gen"
 
 # GeoIP based Language settings: Leave commented out to disable GeoIP.
 #
 # GeoIP needs a working Internet connection.
 # This can be managed from `welcome.conf` by adding
-# internet to the list of required conditions.
+# internet to the list of required conditions. (The welcome
+# module can also do its own GeoIP lookups, independently
+# of the lookup done here. The lookup in the welcome module
+# is used to establish language; this one is for timezone).
 #
-# The configuration
-# is in three parts: a *style*, which can be "json" or "xml"
-# depending on the kind of data returned by the service, and
-# a *url* where the data is retrieved, and an optional *selector*
-# to pick the right field out of the returned data (e.g. field
-# name in JSON or element name in XML).
+# The configuration is in three parts:
+# - a *style*, which can be "json" or "xml" depending on the
+#   kind of data returned by the service, and
+# - a *url* where the data is retrieved, and
+# - an optional *selector*
+#   to pick the right field out of the returned data (e.g. field
+#   name in JSON or element name in XML).
 #
 # The default selector (when the setting is blank) is picked to
 # work with existing JSON providers (which use "time_zone") and
@@ -45,8 +73,8 @@ zone:                       "Rome"
 #
 # If the service configured via *url* uses
 # a different attribute name (e.g. "timezone") in JSON or a
-# different element tag (e.g. "<Time_Zone>") in XML, set this
-# string to the name or tag to be used.
+# different element tag (e.g. "<Time_Zone>") in XML, set the
+# selector to the name or tag to be used.
 #
 # In JSON:
 #  - if the string contains "." characters, this is used as a
@@ -58,7 +86,10 @@ zone:                       "Rome"
 #  - all elements with the named tag (e.g. all TimeZone) elements
 #    from the document are checked; the first one with non-empty
 #    text value is used.
-#
+# Special case:
+#  - the *style* "fixed" is also supported. This ignores the data
+#    returned from the URL (but the URL must still be valid!)
+#    and just returns the value of the *selector*.
 #
 # An HTTP(S) request is made to *url*. The request should return
 # valid data in a suitable format, depending on *style*;
@@ -66,9 +97,6 @@ zone:                       "Rome"
 # in <region>/<zone> format. For services that return data which
 # does not follow the conventions of "suitable data" described
 # below, *selector* may be used to pick different data.
-#
-# Note that this example URL works, but the service is shutting
-# down in June 2018.
 #
 # Suitable JSON data looks like
 # ```
@@ -84,9 +112,6 @@ zone:                       "Rome"
 #  - backslashes are removed
 #  - spaces are replaced with _
 #
-# Legacy settings "geoipStyle", "geoipUrl" and "geoipSelector"
-# in the top-level are still supported, but I'd advise against.
-#
 # To disable GeoIP checking, either comment-out the entire geoip section,
 # or set the *style* key to an unsupported format (e.g. `none`).
 # Also, note the analogous feature in src/modules/welcome/welcome.conf.
@@ -95,3 +120,12 @@ geoip:
     style:    "json"
     url:      "https://geoip.kde.org/v1/calamares"
     selector: ""  # leave blank for the default
+
+# For testing purposes, you could use *fixed* style, to see how Calamares
+# behaves in a particular zone:
+#
+# geoip:
+#     style:    "fixed"
+#     url:      "https://geoip.kde.org/v1/calamares"  # Still needs to be valid!
+#     selector: "America/Vancouver"  # this is the selected zone
+#

--- a/conf/distros/rolling/calamares/modules/luksopenswaphookcfg.yml
+++ b/conf/distros/rolling/calamares/modules/luksopenswaphookcfg.yml
@@ -1,6 +1,5 @@
-# Debian Buster
-# luksopenswaphookcfg
-# Writes an openswap configuration with LUKS settings to the given path
+# Calamares 3.3
+# Arch
 ---
 # Path of the configuration file to write (in the target system)
 configFilePath: /etc/openswap.conf

--- a/conf/distros/rolling/calamares/modules/machineid.yml
+++ b/conf/distros/rolling/calamares/modules/machineid.yml
@@ -1,4 +1,40 @@
+# Calamares 3.3
+# Arch
 ---
+# Whether to create /etc/machine-id for systemd.
+# The default is *false*.
 systemd: true
+
+# Whether to create /var/lib/dbus/machine-id for D-Bus.
+# The default is *false*.
 dbus: true
-symlink: true
+# Whether /var/lib/dbus/machine-id should be a symlink to /etc/machine-id
+# (ignored if dbus is false, or if there is no /etc/machine-id to point to).
+# The default is *false*.
+dbus-symlink: true
+
+# Copy entropy from the host? If this is set to *true*, then
+# any entropy file listed below will be copied from the host
+# if it exists. Non-existent files will be generated from
+# /dev/urandom . The default is *false*.
+entropy-copy: false
+# Which files to write (paths in the target). Each of these files is
+# either generated from /dev/urandom or copied from the host, depending
+# on the setting for *entropy-copy*, above.
+entropy-files:
+    - /var/lib/urandom/random-seed
+    - /var/lib/systemd/random-seed
+
+# Whether to create an entropy file /var/lib/urandom/random-seed
+#
+# DEPRECATED: list the file in entropy-files instead. If this key
+# exists and is set to *true*, a warning is printed and Calamares
+# behaves as if `/var/lib/urandom/random-seed` is listed in *entropy-files*.
+#
+# entropy: false
+
+# Whether to create a symlink for D-Bus
+#
+# DEPRECATED: set *dbus-symlink* with the same meaning instead.
+#
+# symlink: false

--- a/conf/distros/rolling/calamares/modules/mount.yml
+++ b/conf/distros/rolling/calamares/modules/mount.yml
@@ -1,38 +1,115 @@
-# Debian Buster
-# mount
-# Mount filesystems in the target (generally, before treating the
-# target as a usable chroot / "live" system). Filesystems are
-# automatically mounted from the partitioning module. Filesystems
-# listed here are **extra**. The filesystems listed in *extraMounts*
-# are mounted in all target systems. The filesystems listed in
-# *extraMountsEfi* are mounted in the target system **only** if
-# the host machine uses UEFI.
+# calamares 3.3
+# Arch
 ---
 # Extra filesystems to mount. The key's value is a list of entries; each
-# entry has four keys:
+# entry has five keys:
 #   - device    The device node to mount
-#   - fs        The filesystem type to use
+#   - fs (optional) The filesystem type to use
 #   - mountPoint Where to mount the filesystem
-#   - options (optional) Extra options to pass to mount(8)
+#   - options (optional) An array of options to pass to mount
+#   - efi (optional) A boolean that when true is only mounted for UEFI installs
+#
+# The device is not mounted if the mountPoint is unset or if the fs is
+# set to unformatted.
 #
 extraMounts:
-  - device: proc
-    fs: proc
-    mountPoint: /proc
-  - device: sys
-    fs: sysfs
-    mountPoint: /sys
-  - device: /dev
-    mountPoint: /dev
-    options: bind
-  - device: tmpfs
-    fs: tmpfs
-    mountPoint: /run
-  - device: /run/udev
-    mountPoint: /run/udev
-    options: bind
+    - device: proc
+      fs: proc
+      mountPoint: /proc
+    - device: sys
+      fs: sysfs
+      mountPoint: /sys
+    - device: /dev
+      mountPoint: /dev
+      options: [ bind ]
+    - device: tmpfs
+      fs: tmpfs
+      mountPoint: /run
+    - device: /run/udev
+      mountPoint: /run/udev
+      options: [ bind ]
+    - device: efivarfs
+      fs: efivarfs
+      mountPoint: /sys/firmware/efi/efivars
+      efi: true
 
-extraMountsEfi:
-  - device: efivarfs
-    fs: efivarfs
-    mountPoint: /sys/firmware/efi/efivars
+# Btrfs subvolumes to create if root filesystem is on btrfs volume.
+# If *mountpoint* is mounted already to another partition, it is ignored.
+# Separate subvolume for swapfile is handled separately and automatically.
+#
+# It is possible to prevent subvolume creation -- this is likely only relevant
+# for the root (/) subvolume -- by giving an empty string as a subvolume
+# name. In this case no subvolume will be created.
+#
+btrfsSubvolumes:
+    - mountPoint: /
+      subvolume: /@
+      # As an alternative:
+      #
+      # subvolume: ""
+    - mountPoint: /home
+      subvolume: /@home
+    - mountPoint: /var/cache
+      subvolume: /@cache
+    - mountPoint: /var/log
+      subvolume: /@log
+
+# The name of the btrfs subvolume holding the swapfile.  This only used when
+# a swapfile is selected and the root filesystem is btrfs
+#
+btrfsSwapSubvol: /@swap
+
+# The mount options used to mount each filesystem.
+#
+# filesystem contains the name of the filesystem or on of three special
+# values, "default", efi" and "btrfs_swap".  The logic is applied in this manner:
+#   - If the partition is the EFI partition, the "efi" entry will be used
+#   - If the fs is btrfs and the subvolume is for the swapfile,
+#     the "btrfs_swap" entry is used
+#   - If the  filesystem is an exact match for filesystem, that entry is used
+#   - If no match is found in the above, the default entry is used
+#   - If there is no match and no default entry, "defaults" is used
+#   - If the mountOptions key is not present, "defaults" is used
+#
+# Each filesystem entry contains 3 keys, all of which are optional
+#   options - An array of mount options that is used on all disk types
+#   ssdOptions - An array of mount options combined with options for ssds
+#   hddOptions - An array of mount options combined with options for hdds
+# If combining these options results in an empty array, "defaults" is used
+#
+# Example 1
+# In this example, there are specific options for ext4 and btrfs filesystems,
+# the EFI partition and the subvolume holding the btrfs swapfile.  All other
+# filesystems use the default entry.  For the btrfs filesystem, there are
+# additional options specific to hdds and ssds
+#
+# mountOptions:
+#    - filesystem: default
+#      options: [ defaults ]
+#    - filesystem: efi
+#      options: [ defaults, umask=0077 ]
+#    - filesystem: ext4
+#      options: [ defaults, noatime ]
+#    - filesystem: btrfs
+#      options: [ defaults, noatime, compress=zstd:1 ]
+#      ssdOptions: [ discard=async ]
+#      hddOptions: [ autodefrag ]
+#    - filesystem: btrfs_swap
+#      options: [ defaults, noatime ]
+#
+# Example 2
+# In this example there is a single default used by all filesystems
+#
+# mountOptions:
+#    - filesystem: default
+#      options: [ defaults, noatime ]
+#
+mountOptions:
+    - filesystem: default
+      options: [ defaults, noatime ]
+    - filesystem: efi
+      options: [ defaults, umask=0077 ]
+    - filesystem: btrfs
+      options: [ defaults, noatime, compress=lzo ]
+    - filesystem: btrfs_swap
+      options: [ defaults, noatime ]

--- a/conf/distros/rolling/calamares/modules/shellprocess_removelink.yml
+++ b/conf/distros/rolling/calamares/modules/shellprocess_removelink.yml
@@ -1,6 +1,8 @@
+# Calamares 3.3
+# Arch
 --
 dontChroot: false
 timeout: 30
 script:
-    - "rm -r @@ROOT@@/usr/share/applications/install-system.desktop"
+    - "rm -r ${ROOT}/usr/share/applications/install-system.desktop"
    

--- a/src/commands/produce.ts
+++ b/src/commands/produce.ts
@@ -121,16 +121,22 @@ export default class Produce extends Command {
       let theme = 'eggs'
       if (flags.theme !== undefined) {
         theme = flags.theme
-        if (theme.endsWith('/')) {
-          theme = theme.substring(0, theme.length - 1)
+        if (theme.includes('/')) {
+          if (theme.endsWith('/')) {
+            theme = theme.substring(0, theme.length - 1)
+          }
+        } else {
+          const wpath  = `/home/${await Utils.getPrimaryUser()}/.wardrobe/vendors/`
+          theme = wpath + flags.theme 
         }
-        
+
         theme = path.resolve(theme)
         if (!fs.existsSync(theme + '/theme')) {
           console.log('Cannot find theme: ' + theme)
           process.exit()
         }
       }
+
       const i = await Config.thatWeNeed(nointeractive, verbose, cryptedclone)
       if ((i.needApt || i.configurationInstall || i.configurationRefresh || i.distroTemplate) && (await Utils.customConfirm('Select yes to continue...'))) {
         await Config.install(i, nointeractive, verbose)

--- a/src/commands/produce.ts
+++ b/src/commands/produce.ts
@@ -124,14 +124,13 @@ export default class Produce extends Command {
         if (theme.endsWith('/')) {
           theme = theme.substring(0, theme.length - 1)
         }
+        
         theme = path.resolve(theme)
         if (!fs.existsSync(theme + '/theme')) {
           console.log('Cannot find theme: ' + theme)
           process.exit()
         }
       }
-      console.log(`theme: ${theme}`)
-
       const i = await Config.thatWeNeed(nointeractive, verbose, cryptedclone)
       if ((i.needApt || i.configurationInstall || i.configurationRefresh || i.distroTemplate) && (await Utils.customConfirm('Select yes to continue...'))) {
         await Config.install(i, nointeractive, verbose)

--- a/src/commands/tools/ppa.ts
+++ b/src/commands/tools/ppa.ts
@@ -140,6 +140,7 @@ async function debianRemove() {
   await exec('rm -f /etc/apt/trusted.gpg.d/penguins-eggs*')
   await exec('rm -f /etc/apt/sources.list.d/penguins-eggs*')
   await exec('rm -f /usr/share/keyrings/penguins-eggs*')
+  
   await exec('apt-get update')
 }
 

--- a/src/commands/wardrobe/list.ts
+++ b/src/commands/wardrobe/list.ts
@@ -92,12 +92,12 @@ export default class List extends Command {
     for (const costume of costumes) {
       if (fs.existsSync(`${wardrobe}costumes/${costume}/${index}`)) {
         const materials = yaml.load(fs.readFileSync(`${wardrobe}costumes/${costume}/${index}`, 'utf-8')) as IMateria
-        console.log(chalk.cyan(costume) + ': ' + materials.description)
+        console.log('- ' + chalk.cyan(costume) + ': ' + materials.description)
       }
     }
 
-
     console.log()
+
     /**
      * accessories
      */
@@ -106,7 +106,7 @@ export default class List extends Command {
     for (const accessory of accessories) {
       if (fs.existsSync(`${wardrobe}/accessories/${accessory}/${index}`)) {
         const materials = yaml.load(fs.readFileSync(`${wardrobe}/accessories/${accessory}/${index}`, 'utf-8')) as IMateria
-        console.log(chalk.cyan(accessory) + ': ' + materials.description)
+        console.log('- ' + chalk.cyan(accessory) + ': ' + materials.description)
       }
     }
 
@@ -120,10 +120,23 @@ export default class List extends Command {
     for (const server of servers) {
       if (fs.existsSync(`${wardrobe}/servers/${server}/${index}`)) {
         const materials = yaml.load(fs.readFileSync(`${wardrobe}/servers/${server}/${index}`, 'utf-8')) as IMateria
-        console.log(chalk.cyan(server) + ': ' + materials.description)
+        console.log('- ' + chalk.cyan(server) + ': ' + materials.description)
       }
     }
 
     console.log()
+
+    /**
+     * vendors
+     */
+    const vendors = fs.readdirSync(`${wardrobe}/vendors/`)
+    console.log(chalk.green('vendors/themes: '))
+    for (const vendor of vendors) {
+      if (fs.existsSync(`${wardrobe}/vendors/${vendor}/theme`)) {
+        console.log('- ' + chalk.cyan(vendor)) 
+      }
+    }
+    console.log()
+
   }
 }


### PR DESCRIPTION
# calamares 3.3 on Arch

* adding `eggs sudo tools ppa` for Arch, here we set repository `chaotic-aur`;
* removed `rolling-` on the default name for Arch, alle the Arch versions are rolling;
* passed to calamares 3.3 for Arch, change all modules on /etc/calamares/modules
* added list for themes and possibility to call themes without path it they are under default path `~/.wardrobe/vendors/`

