### PR TITLE
eggs-9.5.26_i386

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,19 @@ Detailed instructions for usage are published on the [Penguins' eggs guide](http
 ## Changelog
 Versions are listed on reverse order, the first is the last one. Old versions are moved to [versions](https://sourceforge.net/projects/penguins-eggs/files/DEBS/versions/). 
 
+
+# eggs-9.5.26_i386
+This is a **great news**, I thought will be not possible, and initially I worked to restore eggs-8.17.17, but with more than same tricks, it is possible to get eggs x32, aligned with the x64 version. 
+
+This are the instructions to install it, I tested on LMDE6 x32:
+
+* download the package `eggs-9.5.26_i386.deb`
+* `sudo gdebi eggs_9.5.26_i386.deb`
+* `sudo rm /usr/lib/penguins-eggs/bin/node`
+* `sudo ln -s /usr/bin/node /usr/lib/penguins-eggs/bin/node`
+* `sudo eggs dad -d`
+
+
 # eggs-9.5.26
 I have been working on extending support for penguins-eggs compatibility regarding derivatives, in particular:
 * the file `derivatives.yaml` has been modified.

--- a/documents/x64-to-x32.md
+++ b/documents/x64-to-x32.md
@@ -1,0 +1,11 @@
+# Creating eggs i386
+
+* Create eggs_9.5.26_amd64
+* `pnpm deb -m`
+* `mkdir ~/workdir`
+* `cp eggs_9.5.26_amd64 ~/workdir/eggs_9.5.26_i386 -R`
+* `cd workdir/eggs_9.5.26_i386`
+* `sed DEBIAN/control`
+* edit `DEBIAN/control`: replace: `Architecture: amd64` with  `Architecture: i386`
++ `rm eggs_9.5.26_i386/usr/lib/penguins-eggs/node`
+* `ln -s /usr/bin/node /usr/lib/penguins-eggs/bin/node`

--- a/documents/x64-to-x32.md
+++ b/documents/x64-to-x32.md
@@ -1,13 +1,21 @@
-# Creating eggs i386
-
+# Creation
 * `pnpm deb -m`
+* `sudo su`
 * `cd /home/artisan/penguins-eggs/perrisbrewery/workdir/`
 * `cp eggs_9.5.26_amd64 eggs_9.5.26_i386 -R`
 * `cd eggs_9.5.26_i386`
 * `nano DEBIAN/control`
    * replace: `Architecture: amd64` with  `Architecture: i386`
    * add `nodejs` to the `Depends:`
-+ `rm usr/lib/penguins-eggs/bin/node`
 * `cd ..`
 * ` dpkg-deb --build eggs_9.5.26_i386/`
-* `ln -s /usr/bin/node usr/lib/penguins-eggs/bin/node`
+
+
+# Installation
+* `sudo apt update`
+* `sudo dpkg -i eggs_9.5.26_i386.deb`
+* `sudo apt install -f`
+* `sudo rm /usr/lib/penguins-eggs/bin/node`
+* `sudo ln -s /usr/bin/node /usr/lib/penguins-eggs/bin/node`
+* `sudo eggs dad -d`
+

--- a/documents/x64-to-x32.md
+++ b/documents/x64-to-x32.md
@@ -7,7 +7,7 @@
 * `nano DEBIAN/control`
    * replace: `Architecture: amd64` with  `Architecture: i386`
    * add `nodejs` to the `Depends:`
-+ `rm usr/lib/penguins-eggs/node`
++ `rm usr/lib/penguins-eggs/bin/node`
 * `cd ..`
-* `dpkg-deb build eggs_9.5.26_i386`
+* ` dpkg-deb --build eggs_9.5.26_i386/`
 * `ln -s /usr/bin/node usr/lib/penguins-eggs/bin/node`

--- a/documents/x64-to-x32.md
+++ b/documents/x64-to-x32.md
@@ -1,12 +1,13 @@
 # Creating eggs i386
 
-* Create eggs_9.5.26_amd64
 * `pnpm deb -m`
 * `cd /home/artisan/penguins-eggs/perrisbrewery/workdir/`
 * `cp eggs_9.5.26_amd64 eggs_9.5.26_i386 -R`
 * `cd eggs_9.5.26_i386`
-* `nano DEBIAN/control`: replace: `Architecture: amd64` with  `Architecture: i386`
+* `nano DEBIAN/control`
+   * replace: `Architecture: amd64` with  `Architecture: i386`
+   * add `nodejs` to the `Depends:`
 + `rm usr/lib/penguins-eggs/node`
 * `cd ..`
-* `dpkg build eggs_9.5.26_i386`
+* `dpkg-deb build eggs_9.5.26_i386`
 * `ln -s /usr/bin/node usr/lib/penguins-eggs/bin/node`

--- a/documents/x64-to-x32.md
+++ b/documents/x64-to-x32.md
@@ -6,15 +6,14 @@
 * `cd eggs_9.5.26_i386`
 * `nano DEBIAN/control`
    * replace: `Architecture: amd64` with  `Architecture: i386`
+   * remove: ``
    * add `nodejs` to the `Depends:`
 * `cd ..`
 * ` dpkg-deb --build eggs_9.5.26_i386/`
 
 
-# Installation
-* `sudo apt update`
-* `sudo dpkg -i eggs_9.5.26_i386.deb`
-* `sudo apt install -f`
+# Installation eggs i386 
+* `sudo gdebi eggs_9.5.26_i386.deb`
 * `sudo rm /usr/lib/penguins-eggs/bin/node`
 * `sudo ln -s /usr/bin/node /usr/lib/penguins-eggs/bin/node`
 * `sudo eggs dad -d`

--- a/documents/x64-to-x32.md
+++ b/documents/x64-to-x32.md
@@ -2,10 +2,11 @@
 
 * Create eggs_9.5.26_amd64
 * `pnpm deb -m`
-* `mkdir ~/workdir`
-* `cp eggs_9.5.26_amd64 ~/workdir/eggs_9.5.26_i386 -R`
-* `cd workdir/eggs_9.5.26_i386`
-* `sed DEBIAN/control`
-* edit `DEBIAN/control`: replace: `Architecture: amd64` with  `Architecture: i386`
-+ `rm eggs_9.5.26_i386/usr/lib/penguins-eggs/node`
-* `ln -s /usr/bin/node /usr/lib/penguins-eggs/bin/node`
+* `cd /home/artisan/penguins-eggs/perrisbrewery/workdir/`
+* `cp eggs_9.5.26_amd64 eggs_9.5.26_i386 -R`
+* `cd eggs_9.5.26_i386`
+* `nano DEBIAN/control`: replace: `Architecture: amd64` with  `Architecture: i386`
++ `rm usr/lib/penguins-eggs/node`
+* `cd ..`
+* `dpkg build eggs_9.5.26_i386`
+* `ln -s /usr/bin/node usr/lib/penguins-eggs/bin/node`

--- a/sourceforge/files/ISOS/arcolinux/README.md
+++ b/sourceforge/files/ISOS/arcolinux/README.md
@@ -23,12 +23,9 @@ Remastering it will be an opportunity to get to know it better and follow Erik's
 
 Following are strange animals, where I used ArcoLinux as base in place of Arch, this is interesting to investigate that we can do!
 
-- **egg-of-arcolinux-naked** just an arcolinuxd-v23.09.03-x86_64.iso remestered;
-* **egg-of-arcolinux-colibri** an arcolinuxd-v23.09.03-x86_64.iso remester dressed with colibri;
-
-This is a plain remaster of arcolinuxs-v23.09.03-x86_64.iso
-
-* **egg-of-arcolinux-xfce** 
+- **egg-of-arcolinux-naked** just an arcolinuxd-v23.10.01-x86_64.iso remestered;
+* **egg-of-arcolinux-colibri** an arcolinuxd-v23.10.01-x86_64.iso remester dressed with colibri (xfce + develop);
+* **egg-of-arcolinux-albatros** an arcolinuxd-v23.10.01-x86_64.iso remester dressed with albatros (plasma + develop);
 
 ![ArcoLinux](https://user-images.githubusercontent.com/958613/269377369-92211ec1-eee2-4301-91c6-eb64c52232a6.png)
 

--- a/sourceforge/files/ISOS/devuan/daedalus/README.md
+++ b/sourceforge/files/ISOS/devuan/daedalus/README.md
@@ -22,9 +22,9 @@ All ISOs include eggs, you can udate it with: ```sudo eggs update```.
 
 # Devuan daedalus
 
-## **naked** - just the juice, without GUI. You can start here to build your revolution!
-##  **colibri** A light xfce4 for developers you can easily start to improve eggs installing colibri.
-## **gnome** just a naked Devuan dressed with gnome, customize it!
+* **naked** - just the juice, without GUI. You can start here to build your revolution!
+*  **colibri** A light xfce4 for developers you can easily start to improve eggs installing colibri.
+* **gnome** just a naked Devuan dressed with gnome, customize it!
 
 ## More informations:
 

--- a/sourceforge/files/ISOS/devuan/daedalus/README.md
+++ b/sourceforge/files/ISOS/devuan/daedalus/README.md
@@ -23,6 +23,8 @@ All ISOs include eggs, you can udate it with: ```sudo eggs update```.
 # Devuan daedalus
 
 ## **naked** - just the juice, without GUI. You can start here to build your revolution!
+##  **colibri** A light xfce4 for developers you can easily start to improve eggs installing colibri.
+## **gnome** just a naked Devuan dressed with gnome, customize it!
 
 ## More informations:
 

--- a/sourceforge/files/ISOS/linuxmint/faye/README.md
+++ b/sourceforge/files/ISOS/linuxmint/faye/README.md
@@ -20,7 +20,8 @@ All ISOs include eggs, you can udate it with: ```sudo eggs update```.
 
 # Linux Mint - faye
 
-* **egg-of-linuxmint-faye-cinnamon** - LMDE 5.0 (based on Debian bullseye), cinnamon
+* **egg-of-linuxmint-faye-cinnamon** 32bit - LMDE 5.0 (based on Debian bullseye), cinnamon
+* **egg-of-linuxmint-faye-cinnamon** 64bit - LMDE 5.0 (based on Debian bullseye), cinnamon
 
 # Installing LMDE 6.0 via PXE
 

--- a/sourceforge/files/ISOS/linuxmint/faye/README.md
+++ b/sourceforge/files/ISOS/linuxmint/faye/README.md
@@ -20,8 +20,8 @@ All ISOs include eggs, you can udate it with: ```sudo eggs update```.
 
 # Linux Mint - faye
 
-* **egg-of-linuxmint-faye-cinnamon** 32bit - LMDE 5.0 (based on Debian bullseye), cinnamon
-* **egg-of-linuxmint-faye-cinnamon** 64bit - LMDE 5.0 (based on Debian bullseye), cinnamon
+* **egg-of-linuxmint-faye-cinnamon** 32bit - LMDE 6.0 (based on Debian bookworm) cinnamon
+* **egg-of-linuxmint-faye-cinnamon** 64bit - LMDE 6.0 (based on Debian bookworm), cinnamon
 
 # Installing LMDE 6.0 via PXE
 

--- a/sourceforge/files/ISOS/mx-linux/README.md
+++ b/sourceforge/files/ISOS/mx-linux/README.md
@@ -21,10 +21,10 @@ All ISOs include eggs, you can udate it with: ```sudo eggs update```.
 
 [MX Linux](https://mxlinux.org/) is a cooperative venture between the [antiX](https://antixlinux.com/) and MX Linux communities. It is a family of operating systems that are designed to combine elegant and efficient desktops with high stability and solid performance.  MX’s graphical tools provide an easy way to do a wide variety of tasks, while the Live USB and snapshot tools inherited from antiX add impressive portability and remastering capabilities. Extensive support is available through videos, documentation and a very friendly Forum.
 
-Original MX-Linux have [mx-snapshot](https://github.com/MX-Linux/mx-snapshot) and [mx-installer](https://github.com/MX-Linux/mx-installer) inside, here both are removed in favour of [penguins-eggs](https://github.com/pieroproietti/penguins-eggs) and [calamares](https://github.com/calamares/calamares).
-
 * **egg-of-mx-bookworm-xfce** - remastered version from MX23 XFCE
 * **egg-of-mx-bookworm-plasma** - remastered version from MX23 KDE
+
+**NOTE**: original [MX-Linux ISOs](https://mxlinux.org/download-links/) have [mx-snapshot](https://github.com/MX-Linux/mx-snapshot) and [mx-installer](https://github.com/MX-Linux/mx-installer) inside, here both are removed in favour of [penguins-eggs](https://github.com/pieroproietti/penguins-eggs) and [calamares](https://github.com/calamares/calamares).
 
 # Installing MX Linux via PXE
 

--- a/sourceforge/files/ISOS/mx-linux/README.md
+++ b/sourceforge/files/ISOS/mx-linux/README.md
@@ -21,7 +21,10 @@ All ISOs include eggs, you can udate it with: ```sudo eggs update```.
 
 [MX Linux](https://mxlinux.org/) is a cooperative venture between the [antiX](https://antixlinux.com/) and MX Linux communities. It is a family of operating systems that are designed to combine elegant and efficient desktops with high stability and solid performance.  MX’s graphical tools provide an easy way to do a wide variety of tasks, while the Live USB and snapshot tools inherited from antiX add impressive portability and remastering capabilities. Extensive support is available through videos, documentation and a very friendly Forum.
 
-* **egg-of-mx-bullseye-xfce** - remastered version from MX21
+Original MX-Linux have [mx-snapshot](https://github.com/MX-Linux/mx-snapshot) and [mx-installer](https://github.com/MX-Linux/mx-installer) inside, here both are removed in favour of [penguins-eggs](https://github.com/pieroproietti/penguins-eggs) and [calamares](https://github.com/calamares/calamares).
+
+* **egg-of-mx-bookworm-xfce** - remastered version from MX23 XFCE
+* **egg-of-mx-bookworm-plasma** - remastered version from MX23 KDE
 
 # Installing MX Linux via PXE
 

--- a/sourceforge/files/ISOS/ubuntu/focal/README:md
+++ b/sourceforge/files/ISOS/ubuntu/focal/README:md
@@ -33,17 +33,6 @@ A light xfce4 for developers you can easily start to improve eggs installing col
 
 ![colibri](https://a.fsdn.com/con/app/proj/penguins-eggs/screenshots/colibri.png/245/183)
 
-## **duck**
-cinnamon, office, multimedia with 5.17.0-1.2-liquorix-amd64 kernel.
-
-![duck](https://a.fsdn.com/con/app/proj/penguins-eggs/screenshots/duck.png/245/183)
- 
-## **owl**
-xfce4 for graphics designers, with 5.17.0-1.2-liquorix-amd64 kernel, based on the work of Clarlie Martinez 
- [quirinux](https://quirinux.org/).
-
-![owl](https://a.fsdn.com/con/app/proj/penguins-eggs/screenshots/owl.png/245/183)
-
 ## More informations:
 
 * Repository: [penguins-eggs](https://github.com/pieroproietti/penguins-eggs)

--- a/sourceforge/files/ISOS/ubuntu/jammy/README.md
+++ b/sourceforge/files/ISOS/ubuntu/jammy/README.md
@@ -38,17 +38,6 @@ A light xfce4 for developers you can easily start to improve eggs installing col
 
 ![colibri](https://a.fsdn.com/con/app/proj/penguins-eggs/screenshots/colibri.png/245/183)
 
-## **duck**
-cinnamon, office, multimedia with 5.17.0-1.2-liquorix-amd64 kernel.
-
-![duck](https://a.fsdn.com/con/app/proj/penguins-eggs/screenshots/duck.png/245/183)
- 
-## **owl**
-xfce4 for graphics designers, with 5.17.0-1.2-liquorix-amd64 kernel, based on the work of Clarlie Martinez 
- [quirinux](https://quirinux.org/).
-
-![owl](https://a.fsdn.com/con/app/proj/penguins-eggs/screenshots/owl.png/245/183)
-
 # That's all Folks!
 No need other configurations, penguins-eggs are battery included or better, as in the real, live is inside! :-D
 

--- a/src/classes/ovary.ts
+++ b/src/classes/ovary.ts
@@ -1275,7 +1275,9 @@ export default class Ovary {
        * creazione dei link in /usr/share/applications
        */
       shx.cp(path.resolve(__dirname, '../../assets/penguins-eggs.desktop'), '/usr/share/applications/')
-
+      /**
+       * f=Scrivania/install-system.desktop; gio set -t string $f metadata::xfce-exe-checksum "$(sha256sum $f | awk '{print $1}'
+       */
       let installerUrl = 'install-system.desktop'
       let installerIcon = 'install-system.sh'
       if (Pacman.calamaresExists()) {

--- a/src/classes/pve-live.ts
+++ b/src/classes/pve-live.ts
@@ -72,7 +72,10 @@ export default class PveLive {
     // this.systemctl.start('pve-ha-lrm')
   }
 
+  /**
+   * 
+   */
   stop() {
-    this.systemctl.start('pve-live')
+    this.systemctl.stop('pve-live')
   }
 }


### PR DESCRIPTION

This is a **great news**, I thought will be not possible, and initially I worked to restore eggs-8.17.17, but with more than same tricks, it is possible to get eggs x32, aligned with the x64 version. 

This are the instructions to install it, I tested on LMDE6 x32:

* download the package `eggs-9.5.26_i386.deb`
* `sudo gdebi eggs_9.5.26_i386.deb`
* `sudo rm /usr/lib/penguins-eggs/bin/node`
* `sudo ln -s /usr/bin/node /usr/lib/penguins-eggs/bin/node`
* `sudo eggs dad -d`

![installing'faye-i386](https://github.com/pieroproietti/penguins-eggs/assets/958613/4631f6c6-047c-4fb6-b757-0722b410cec9)
