### PR TITLE
Ignore files from user's homes while creating a crypted clone

### DIFF
--- a/conf/exclude.list.cryptedclone
+++ b/conf/exclude.list.cryptedclone
@@ -1,0 +1,6 @@
+######################################################################################################
+# CRYPTEDCLONE: You can add yours exclusions here
+#
+# Remember that the starting path is relative to the user home
+#
+# private/private.file

--- a/conf/exclude.list.custom
+++ b/conf/exclude.list.custom
@@ -1,3 +1,3 @@
 ######################################################################################################
-# CUSTOM: You can add yours exclusions here: expample
+# CUSTOM: You can add yours exclusions here: example
 # blissos/data.img

--- a/src/classes/ovary.ts
+++ b/src/classes/ovary.ts
@@ -331,7 +331,13 @@ export default class Ovary {
       }
 
       if (cryptedclone) {
-        await exec('eggs syncto', Utils.setEcho(true))
+        let synctoCmd = `eggs syncto -f ${luksFile}`
+
+        if (filters.cryptedclone) {
+          synctoCmd += ' -e'
+        }
+
+        await exec(`${synctoCmd}`, Utils.setEcho(true))
         Utils.warning(`Waiting 10s, before to move ${luksFile} in ${this.nest}iso/live`)
         await exec('sleep 10', Utils.setEcho(false))
         Utils.warning(`moving ${luksFile} in ${this.nest}iso/live`)
@@ -1558,44 +1564,44 @@ merged(dir: string): boolean {
    * @param icon
    */
   private lxdeLink(file: string, name: string, icon: string): string {
-  if (this.verbose) {
-    console.log('Ovary: lxdeLink')
+    if (this.verbose) {
+      console.log('Ovary: lxdeLink')
+    }
+
+    const lnk = `lnk-${file}`
+
+    let text = ''
+    text += `echo "[Desktop Entry]" >$DESKTOP/${lnk}\n`
+    text += `echo "Type=Link" >> $DESKTOP/${lnk}\n`
+    text += `echo "Name=${name}" >> $DESKTOP/${lnk}\n`
+    text += `echo "Icon=${icon}" >> $DESKTOP/${lnk}\n`
+    text += `echo "URL=/usr/share/applications/${file}" >> $DESKTOP/${lnk}\n\n`
+
+    return text
   }
 
-  const lnk = `lnk-${file}`
+  /**
+   * Add or remove exclusion
+   * @param add {boolean} true = add, false remove
+   * @param exclusion {string} path to add/remove
+   */
+  addRemoveExclusion(add: boolean, exclusion: string): void {
+    if(this.verbose) {
+      console.log('Ovary: addRemoveExclusion')
+    }
 
-  let text = ''
-  text += `echo "[Desktop Entry]" >$DESKTOP/${lnk}\n`
-  text += `echo "Type=Link" >> $DESKTOP/${lnk}\n`
-  text += `echo "Name=${name}" >> $DESKTOP/${lnk}\n`
-  text += `echo "Icon=${icon}" >> $DESKTOP/${lnk}\n`
-  text += `echo "URL=/usr/share/applications/${file}" >> $DESKTOP/${lnk}\n\n`
+    if (exclusion.startsWith('/')) {
+      exclusion = exclusion.slice(1) // remove / initial Non compatible with rsync
+    }
 
-  return text
-}
-
-/**
- * Add or remove exclusion
- * @param add {boolean} true = add, false remove
- * @param exclusion {atring} path to add/remove
- */
-addRemoveExclusion(add: boolean, exclusion: string): void {
-  if(this.verbose) {
-  console.log('Ovary: addRemoveExclusion')
-}
-
-if (exclusion.startsWith('/')) {
-  exclusion = exclusion.slice(1) // remove / initial Non compatible with rsync
-}
-
-if (add) {
-  this.settings.session_excludes += this.settings.session_excludes === '' ? `-e '${exclusion}' ` : ` '${exclusion}' `
-} else {
-  this.settings.session_excludes.replace(` '${exclusion}'`, '')
-  if (this.settings.session_excludes === '-e') {
-    this.settings.session_excludes = ''
-  }
-}
+    if (add) {
+      this.settings.session_excludes += this.settings.session_excludes === '' ? `-e '${exclusion}' ` : ` '${exclusion}' `
+    } else {
+      this.settings.session_excludes.replace(` '${exclusion}'`, '')
+      if (this.settings.session_excludes === '-e') {
+        this.settings.session_excludes = ''
+      }
+    }
   }
 
   // #######################################################################################

--- a/src/classes/pacman.ts
+++ b/src/classes/pacman.ts
@@ -444,6 +444,7 @@ export default class Pacman {
 
     // creazione cartella exclude.list.d
     execSync(`mkdir -p /etc/penguins-eggs.d/exclude.list.d`)
+    shx.cp(path.resolve(__dirname, '../../conf/exclude.list.cryptedclone'), '/etc/penguins-eggs.d/exclude.list.d')
     shx.cp(path.resolve(__dirname, '../../conf/exclude.list.template'), '/etc/penguins-eggs.d/exclude.list.d')
     shx.cp(path.resolve(__dirname, '../../conf/exclude.list.custom'), '/etc/penguins-eggs.d/exclude.list.d')
     shx.cp(path.resolve(__dirname, '../../conf/exclude.list.homes'), '/etc/penguins-eggs.d/exclude.list.d')

--- a/src/commands/produce.ts
+++ b/src/commands/produce.ts
@@ -22,7 +22,7 @@ export default class Produce extends Command {
     basename: Flags.string({ description: 'basename' }),
     clone: Flags.boolean({ char: 'c', description: 'clone' }),
     cryptedclone: Flags.boolean({ char: 'C', description: 'crypted clone' }),
-    filters: Flags.string({ multiple: true, description: 'filters can be used: custom. dev, homes, usr' }),
+    filters: Flags.string({ multiple: true, description: 'filters can be used: custom. dev, homes, usr, cryptedclone' }),
     help: Flags.help({ char: 'h' }),
     links:  Flags.string({ multiple: true, description: 'desktop links' }),
     max: Flags.boolean({ char: 'm', description: 'max compression' }),
@@ -48,6 +48,7 @@ export default class Produce extends Command {
     'sudo eggs produce --clone',
     'sudo eggs produce --basename=colibri',
     'sudo eggs produce --basename=colibri --theme theme --addons adapt',
+    'sudo eggs produce --filters=custom --filters=homes'
   ]
 
   async run(): Promise<void> {
@@ -107,6 +108,8 @@ export default class Produce extends Command {
       filters.dev = false
       filters.homes = false
       filters.usr = false
+      filters.cryptedclone = false
+
       if (flags.filters) {
         if (flags.filters.includes('custom')) {
           filters.custom = true
@@ -119,6 +122,9 @@ export default class Produce extends Command {
         }
         if (flags.filters.includes('usr')) {
           filters.usr = true
+        }
+        if (flags.filters.includes('cryptedclone')) {
+          filters.cryptedclone = true
         }
       }
 

--- a/src/interfaces/i-filters.ts
+++ b/src/interfaces/i-filters.ts
@@ -6,6 +6,7 @@
  * license: MIT
  */
 export interface IFilters {
+  cryptedclone: boolean
   custom: boolean
   dev: boolean
   homes: boolean


### PR DESCRIPTION
I had the need to exclude some files during the creation of the LUKS crypted copy.

With this feature is possible to choose which files are to be filtered from the crypted copy by using the template file `exclude.list.cryptedclone` inside the directory _/etc/penguins-eggs.d/exclude.list.d/_.

The cryptedclone exclusion can be invoked in the same way as other exclusions, using the `filters` flag of the command _produce_.

`sudo eggs produce --filters=cryptedclone --cryptedclone`

Keep in mind that the paths specified in the _exclude.list.cryptedclone_ file are relative to each user's home directory.

Under the hood the command `eggs produce` invokes the command `eggs syncto` to create the LUKS file. I added to this command a new flag `-e` or `--exclude` that enable the cryptedclone exclusion.

`sudo eggs syncto -e`

I also took the opportunity to fix some small formatting issues and variable names, I hope I'm not considered too picky 😃 