### PR TITLE
Riparazione danni su ARCH

### DIFF
--- a/src/classes/utils.tsx
+++ b/src/classes/utils.tsx
@@ -461,7 +461,8 @@ export default class Utils {
    static uefiFormat(): string {
       let format = ''
       if (process.arch === 'ia32') {
-         format = 'i386-pc'
+         //format = 'i386-pc'
+         format = 'i386-efi'
          if (shx.exec('uname -m', { silent: true }).stdout.trim() === 'x86_64') {
             format = 'x86_64-efi'
          }

--- a/src/classes/utils.tsx
+++ b/src/classes/utils.tsx
@@ -453,16 +453,19 @@ export default class Utils {
 
    /**
     * i386-pc,
+    * i386-efi,
     * x86_64-efi, 
     * arm64-efi,
+    * 
+    * ATTEMZIONE: install efibootmgr
     * 
     * Fedora/RHEL have i386-pc
     */
    static uefiFormat(): string {
       let format = ''
       if (process.arch === 'ia32') {
-         //format = 'i386-pc'
-         format = 'i386-efi'
+         //format = 'i386-pc' // rf
+         format = 'i386-efi' // arch
          if (shx.exec('uname -m', { silent: true }).stdout.trim() === 'x86_64') {
             format = 'x86_64-efi'
          }


### PR DESCRIPTION
Ad un certo punto non funzionava più UEFI su ARCH, probabilmente era dovuto alla mancanza di efibootmgr o alla designazione di i386-pc al posto di i386-efi.

In mancanza di meglio le ho cambiate entrambe.