### PR TITLE
2025-04-08 kernel-overlay-install before penguins-eggs-install

### DIFF
--- a/pods/ci.local/penguins-eggs-install.sh
+++ b/pods/ci.local/penguins-eggs-install.sh
@@ -87,7 +87,7 @@ function tarballs_install {
 if [ -f /etc/os-release ]; then
     . /etc/os-release
     if [[ "$ID" == "debian" ]]; then
-        debs_install
+        tarballs_install
     elif [[ "$ID" == "devuan" ]]; then
         debs_install
     elif [[ "$ID" == "ubuntu" ]]; then

--- a/pods/ci.local/run-on-almalinux.sh
+++ b/pods/ci.local/run-on-almalinux.sh
@@ -36,11 +36,11 @@ dnf -y update
 # packages to be added for a minimum standard installation
 source ./minimal/almalinux-container2host.sh
 
-# installing ggs
-source ./penguins-eggs-install.sh
-
 # test mount -t overlay
 source ./kernel-overlay-install.sh
+
+# installing eggs
+source ./penguins-eggs-install.sh
 
 # systemd
 systemctl set-default multi-user.target

--- a/pods/ci.local/run-on-archlinux.sh
+++ b/pods/ci.local/run-on-archlinux.sh
@@ -36,11 +36,11 @@ pacman -Syu --noconfirm
 # packages to be added for a minimum standard installation
 source ./minimal/archlinux-container2host.sh
 
-# installing ggs
-source ./penguins-eggs-install.sh
-
 # test mount -t overlay
 source ./kernel-overlay-install.sh
+
+# installing ggs
+source ./penguins-eggs-install.sh
 
 # systemd
 systemctl set-default multi-user.target

--- a/pods/ci.local/run-on-debian.sh
+++ b/pods/ci.local/run-on-debian.sh
@@ -36,11 +36,11 @@ apt upgrade -y
 # packages to be added for a minimum standard installation
 source ./minimal/debian-container2host.sh
 
-# installing ggs
-source ./penguins-eggs-install.sh
-
 # test mount -t overlay
 source ./kernel-overlay-install.sh
+
+# installing ggs
+source ./penguins-eggs-install.sh
 
 # systemd
 systemctl set-default multi-user.target

--- a/pods/ci.local/run-on-devuan.sh
+++ b/pods/ci.local/run-on-devuan.sh
@@ -38,11 +38,11 @@ apt upgrade -y
 # packages to be added for a minimum standard installation
 source ./minimal/debian-container2host.sh
 
-# installing ggs
-source ./penguins-eggs-install.sh
-
 # test mount -t overlay
 source ./kernel-overlay-install.sh
+
+# installing ggs
+source ./penguins-eggs-install.sh
 
 # execute eggs
 source ./penguins-eggs-execute.sh

--- a/pods/ci.local/run-on-fedora.sh
+++ b/pods/ci.local/run-on-fedora.sh
@@ -36,11 +36,12 @@ dnf -y update
 # packages to be added for a minimum standard installation
 source ./minimal/fedora-container2host.sh
 
-# installing ggs
-source ./penguins-eggs-install.sh
 
 # test mount -t overlay
 source ./kernel-overlay-install.sh
+
+# installing ggs
+source ./penguins-eggs-install.sh
 
 # systemd
 systemctl set-default multi-user.target

--- a/pods/ci.local/run-on-manjaro.sh
+++ b/pods/ci.local/run-on-manjaro.sh
@@ -36,11 +36,11 @@ pacman -Syu --noconfirm
 source ./minimal/manjaro-container2host.sh
 
 
-# installing eggs
-source ./penguins-eggs-install.sh
-
 # test mount -t overlay
 source ./kernel-overlay-install.sh
+
+# installing eggs
+source ./penguins-eggs-install.sh
 
 # systemd
 systemctl set-default multi-user.target

--- a/pods/ci.local/run-on-rockylinux.sh
+++ b/pods/ci.local/run-on-rockylinux.sh
@@ -36,11 +36,12 @@ dnf -y update
 # packages to be added for a minimum standard installation
 source ./minimal/almalinux-container2host.sh
 
-# installing ggs
-source ./penguins-eggs-install.sh
 
 # test mount -t overlay
 source ./kernel-overlay-install.sh
+
+# installing ggs
+source ./penguins-eggs-install.sh
 
 # systemd
 systemctl set-default multi-user.target

--- a/pods/ci.local/run-on-ubuntu.sh
+++ b/pods/ci.local/run-on-ubuntu.sh
@@ -38,11 +38,11 @@ apt upgrade -y
 # packages to be added for a minimum standard installation
 source ./minimal/debian-container2host.sh
 
-# installing ggs
-source ./penguins-eggs-install.sh
-
 # test mount -t overlay
 source ./kernel-overlay-install.sh
+
+# installing ggs
+source ./penguins-eggs-install.sh
 
 # systemd
 systemctl set-default multi-user.target


### PR DESCRIPTION
Inverted on the various script `run-as-almalinux.sh`, `run-as-archlinux.sh`, etc the sequence, now `kernel-overlay-install.sh` is called before to `penguins-eggs-install.sh`. 

This becouse, almost on Debian, installing eggs from deb package  look for `/usr/lib/modules/` not existing on containers.