### PR TITLE
Correct README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1242,7 +1242,7 @@ _See code: [@oclif/plugin-version](https://github.com/oclif/plugin-version/blob/
 
 ## `eggs wardrobe get [REPO]`
 
-get warorobe
+get wardrobe
 
 ```
 USAGE
@@ -1256,7 +1256,7 @@ FLAGS
   -v, --verbose
 
 DESCRIPTION
-  get warorobe
+  get wardrobe
 
 EXAMPLES
   $ eggs wardrobe get


### PR DESCRIPTION
I noticed that you misspelled the word "wardrobe" as "warorobe" a couple times.
This non-critical pull request should correct it.